### PR TITLE
fix: handle Chinese full-width comma (U+FF0C) in CSV parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1,7 +1,11 @@
 /**
  * Simple CSV Parser
  * Parses CSV text into an array of arrays
+ * Supports both ASCII comma (,) and Chinese full-width comma (，)
  */
+
+// Match ASCII comma (U+002C) or full-width comma (U+FF0C)
+const COMMA_PATTERN = /,|，/;
 
 function parseCSV(text) {
   if (!text || typeof text !== 'string') {
@@ -9,9 +13,7 @@ function parseCSV(text) {
   }
 
   const rows = text.trim().split('\n');
-  // BUG: Only splits on ASCII comma (U+002C)
-  // Does NOT handle Chinese full-width comma (U+FF0C) "，"
-  return rows.map(row => row.split(',').map(cell => cell.trim()));
+  return rows.map(row => row.split(COMMA_PATTERN).map(cell => cell.trim()));
 }
 
 module.exports = { parseCSV };

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -19,9 +19,9 @@ function assert(name, actual, expected) {
 
 console.log('\n📋 CSV Parser Tests\n');
 
-// Test 1: Basic CSV
+// Test 1: Basic CSV with ASCII commas
 assert(
-  'parses basic CSV',
+  'parses basic CSV with ASCII commas',
   parseCSV('a,b,c\n1,2,3'),
   [['a', 'b', 'c'], ['1', '2', '3']]
 );
@@ -39,6 +39,25 @@ assert(
   parseCSV('hello,world'),
   [['hello', 'world']]
 );
+
+// Test 4: Chinese full-width commas (U+FF0C) — THE BUG FIX
+assert(
+  'parses CSV with Chinese full-width commas',
+  parseCSV('名字，年龄，城市\n张三，25，北京'),
+  [['名字', '年龄', '城市'], ['张三', '25', '北京']]
+);
+
+// Test 5: Mixed ASCII and full-width commas
+assert(
+  'handles mixed comma types',
+  parseCSV('a,b，c'),
+  [['a', 'b', 'c']]
+);
+
+// Test 6: Regression - empty input throws
+let threwError = false;
+try { parseCSV(''); } catch (e) { threwError = true; }
+assert('throws on empty input', threwError, true);
 
 console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes #1

The CSV parser only recognized ASCII commas (`,` U+002C) as delimiters. This PR adds support for Chinese full-width commas (`，` U+FF0C).

## Changes

- Updated `COMMA_PATTERN` regex to match both comma variants
- Added 3 new test cases (full-width comma, mixed commas, regression)
- All 6 tests passing

## BountyPay Claim

| Field | Value |
|-------|-------|
| Bounty | $80 USD1 |
| Wallet | `0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18` |
| Agent | claude-coding-agent |

> 🤖 This PR was submitted by an AI coding agent via BountyPay.
> Payment will be automatically triggered on merge.