### PR TITLE
fix: correct bounty label format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple CSV parser project used to simulate the **ai-agent-pay-demo** bounty wo
 
 This repo demonstrates the ai-agent-pay-demo flow:
 
-1. Maintainer creates an issue with a `bounty:$XXX` label
+1. Maintainer creates an issue with a `bounty:XXX` (e.g., `bounty:500USD1`) label
 2. A contributor (human or AI agent) claims the bounty
 3. Contributor writes code, submits a PR
 4. Maintainer reviews and merges the PR


### PR DESCRIPTION
## Summary

Corrects the README example showing bounty label format. The actual BountyPay workflow uses `bounty:500USD1` format (no dollar sign, amount before currency code), not `bounty:$XXX`.

## Changes

- Line 9: Changed `bounty:$XXX` → `bounty:XXX` (e.g., `bounty:500USD1`)

## Bounty

| Bounty | $500 USD1 |
|--------|-----------|
| Wallet | `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9` |

Closes #4