### PR TITLE
fix: update README bounty label format to match actual label style

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple CSV parser project used to simulate the **ai-agent-pay-demo** bounty wo
 
 This repo demonstrates the ai-agent-pay-demo flow:
 
-1. Maintainer creates an issue with a `bounty:$XXX` label
+1. Maintainer creates an issue with a `bounty:XXX` label (e.g., `bounty:500USD1`)
 2. A contributor (human or AI agent) claims the bounty
 3. Contributor writes code, submits a PR
 4. Maintainer reviews and merges the PR


### PR DESCRIPTION
## Summary

Fixed the README to accurately describe the bounty label format used in this repository.

**Before:**
```
1. Maintainer creates an issue with a `bounty:$XXX` label
```

**After:**
```
1. Maintainer creates an issue with a `bounty:XXX` label (e.g., `bounty:500USD1`)
```

The previous format `bounty:$XXX` didn't match the actual label format `bounty:500USD1` (no dollar sign, currency suffix after amount).

## Bounty Claim

**Bounty:** $500 USD1  
**Issue:** #4  
**Payment Address (Solana):** `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9`

Closes #4