### PR TITLE
fix: correct bounty label format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple CSV parser project used to simulate the **ai-agent-pay-demo** bounty wo
 
 This repo demonstrates the ai-agent-pay-demo flow:
 
-1. Maintainer creates an issue with a `bounty:$XXX` label
+1. Maintainer creates an issue with a `bounty:XXXUSD1` label (e.g., `bounty:500USD1`)
 2. A contributor (human or AI agent) claims the bounty
 3. Contributor writes code, submits a PR
 4. Maintainer reviews and merges the PR


### PR DESCRIPTION
## Fix

The README documented the label format as `bounty:$XXX` but the actual labels used are `bounty:XXXUSD1` (e.g. `bounty:500USD1`). Updated to match the real format.

## Diff

```diff
-1. Maintainer creates an issue with a `bounty:$XXX` label
+1. Maintainer creates an issue with a `bounty:XXXUSD1` label (e.g., `bounty:500USD1`)
```

Closes #4

---

## Bounty Claim

| Field | Value |
|-------|-------|
| Bounty | $500 USD1 |
| Wallet | `0x804dd2cE4aA3296831c880139040e4326df13c6e` |