### PR TITLE
docs: fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ The CSV parser does not handle Chinese full-width commas (U+FF0C `，`). See Iss
 
 ## Error Handling
 Added proper timeout handling for all API calls.
-// Webhook integration implemented
+Webhook integration implemented.


### PR DESCRIPTION
## Summary\n- Fixes a stray JavaScript-style comment marker in the README text\n- Adds normal sentence punctuation for the webhook integration note\n\nCloses #4\n\n## Test plan\n- Documentation-only change; no tests run