### PR TITLE
fix: handle empty API responses safely

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,74 @@
+/**
+ * Helpers for safely handling API responses in UI code.
+ *
+ * Empty API responses are converted into friendly error states so callers can
+ * show a toast instead of crashing while reading missing fields.
+ */
+
+const DEFAULT_EMPTY_RESPONSE_MESSAGE =
+  'We could not load this data. Please try again in a moment.';
+
+function createErrorToast(message = DEFAULT_EMPTY_RESPONSE_MESSAGE) {
+  return {
+    type: 'error',
+    message,
+  };
+}
+
+function emptyApiResponse(message = DEFAULT_EMPTY_RESPONSE_MESSAGE) {
+  return {
+    ok: false,
+    data: null,
+    error: {
+      code: 'EMPTY_API_RESPONSE',
+      message,
+    },
+    toast: createErrorToast(message),
+  };
+}
+
+function apiResponseError(error, fallbackMessage = DEFAULT_EMPTY_RESPONSE_MESSAGE) {
+  const message = error instanceof Error && error.message
+    ? error.message
+    : fallbackMessage;
+
+  return {
+    ok: false,
+    data: null,
+    error: {
+      code: 'API_RESPONSE_ERROR',
+      message,
+    },
+    toast: createErrorToast(message),
+  };
+}
+
+function handleApiResponse(response, options = {}) {
+  const message = options.emptyMessage || DEFAULT_EMPTY_RESPONSE_MESSAGE;
+
+  if (response === null || response === undefined) {
+    return emptyApiResponse(message);
+  }
+
+  return {
+    ok: true,
+    data: response,
+    error: null,
+    toast: null,
+  };
+}
+
+async function safeApiCall(fetcher, options = {}) {
+  try {
+    return handleApiResponse(await fetcher(), options);
+  } catch (error) {
+    return apiResponseError(error, options.errorMessage);
+  }
+}
+
+module.exports = {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  createErrorToast,
+  handleApiResponse,
+  safeApiCall,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,121 @@
+const {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  handleApiResponse,
+  safeApiCall,
+} = require('../src/api-response');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+async function run() {
+  console.log('\n📋 API Response Tests\n');
+
+  assert(
+    'wraps successful API responses',
+    handleApiResponse({ bounties: [{ id: 1 }] }),
+    {
+      ok: true,
+      data: { bounties: [{ id: 1 }] },
+      error: null,
+      toast: null,
+    }
+  );
+
+  assert(
+    'handles null API responses without throwing',
+    handleApiResponse(null),
+    {
+      ok: false,
+      data: null,
+      error: {
+        code: 'EMPTY_API_RESPONSE',
+        message: DEFAULT_EMPTY_RESPONSE_MESSAGE,
+      },
+      toast: {
+        type: 'error',
+        message: DEFAULT_EMPTY_RESPONSE_MESSAGE,
+      },
+    }
+  );
+
+  assert(
+    'handles undefined API responses without throwing',
+    handleApiResponse(undefined, { emptyMessage: 'No bounties were returned.' }),
+    {
+      ok: false,
+      data: null,
+      error: {
+        code: 'EMPTY_API_RESPONSE',
+        message: 'No bounties were returned.',
+      },
+      toast: {
+        type: 'error',
+        message: 'No bounties were returned.',
+      },
+    }
+  );
+
+  assert(
+    'does not treat valid falsy API data as empty',
+    [handleApiResponse(0).ok, handleApiResponse(false).ok, handleApiResponse('').ok],
+    [true, true, true]
+  );
+
+  assert(
+    'safeApiCall returns a friendly toast when the API throws',
+    await safeApiCall(
+      async () => {
+        throw new Error('Network unavailable');
+      },
+      { errorMessage: 'Unable to load bounties.' }
+    ),
+    {
+      ok: false,
+      data: null,
+      error: {
+        code: 'API_RESPONSE_ERROR',
+        message: 'Network unavailable',
+      },
+      toast: {
+        type: 'error',
+        message: 'Network unavailable',
+      },
+    }
+  );
+
+  assert(
+    'safeApiCall handles an empty resolved response',
+    await safeApiCall(async () => null),
+    {
+      ok: false,
+      data: null,
+      error: {
+        code: 'EMPTY_API_RESPONSE',
+        message: DEFAULT_EMPTY_RESPONSE_MESSAGE,
+      },
+      toast: {
+        type: 'error',
+        message: DEFAULT_EMPTY_RESPONSE_MESSAGE,
+      },
+    }
+  );
+
+  console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a zero-dependency API response helper that converts null/undefined API responses into a safe error state
- include a friendly error-toast payload for UI callers instead of forcing callers to read missing fields and crash
- keep valid falsy responses like `0`, `false`, and empty string as successful data
- wire new plain Node regression tests into `npm test`

## Verification
- `npm test`