### PR TITLE
Handle empty API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,29 @@
+const DEFAULT_EMPTY_RESPONSE_MESSAGE =
+  'We could not load data from the API. Please try again in a moment.';
+
+function isEmptyApiResponse(response) {
+  return response === null || response === undefined || response === '';
+}
+
+function notifyError(onError, message) {
+  if (typeof onError === 'function') {
+    onError(message);
+  }
+}
+
+function handleApiResponse(response, options = {}) {
+  const message = options.emptyMessage || DEFAULT_EMPTY_RESPONSE_MESSAGE;
+
+  if (isEmptyApiResponse(response)) {
+    notifyError(options.onError, message);
+    return { ok: false, error: message, data: null };
+  }
+
+  return { ok: true, error: null, data: response };
+}
+
+module.exports = {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  handleApiResponse,
+  isEmptyApiResponse,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,53 @@
+const {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  handleApiResponse,
+  isEmptyApiResponse,
+} = require('../src/api-response');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  PASS ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+console.log('\nAPI Response Error Handling Tests\n');
+
+assert('detects null API responses as empty', isEmptyApiResponse(null), true);
+assert('detects undefined API responses as empty', isEmptyApiResponse(undefined), true);
+assert('detects empty string API responses as empty', isEmptyApiResponse(''), true);
+assert('does not treat empty objects as empty responses', isEmptyApiResponse({}), false);
+
+const toasts = [];
+const emptyResult = handleApiResponse(undefined, {
+  onError: message => toasts.push(message),
+});
+
+assert('returns a friendly error result for empty responses', emptyResult, {
+  ok: false,
+  error: DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  data: null,
+});
+assert('shows a friendly error toast for empty responses', toasts, [
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+]);
+
+const successPayload = { id: 1, status: 'paid' };
+assert('passes through valid API responses', handleApiResponse(successPayload), {
+  ok: true,
+  error: null,
+  data: successPayload,
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #35

Bounty: $50 USD1
Wallet: `0xEF8139503b8416FB0eded1d33F7eBcCA3C32A83E`

## Summary
- Added a safe API response helper that handles `null`, `undefined`, and empty string responses without throwing.
- Returns a friendly error result and invokes an error callback that UI code can wire to a toast.
- Added regression coverage for empty responses, toast handling, and valid response passthrough.

## Tests
- `npm.cmd test`