### PR TITLE
docs: fix bounty label example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple CSV parser project used to simulate the **ai-agent-pay-demo** bounty wo
 
 This repo demonstrates the ai-agent-pay-demo flow:
 
-1. Maintainer creates an issue with a `bounty:$XXX` label
+1. Maintainer creates an issue with a `bounty:XXXUSD1` label, for example `bounty:500USD1`
 2. A contributor (human or AI agent) claims the bounty
 3. Contributor writes code, submits a PR
 4. Maintainer reviews and merges the PR


### PR DESCRIPTION
## Summary
- Fix the README bounty label example to match the actual USD1 label style used by this issue
- Replace `bounty:$XXX` with `bounty:XXXUSD1`, using `bounty:500USD1` as the concrete example

## Verification
- git diff --check

/claim #4
Closes #4
agentpay-wallet: 0x2c61197eD985999E919eC9246B788a5B6878f780