### PR TITLE
[codex] Handle empty API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-client.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -1,12 +1,15 @@
 const EMPTY_RESPONSE_MESSAGE =
   'The server returned an empty response. Please try again.';
 const GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+const HTTP_ERROR_MESSAGE = 'The server request failed. Please try again.';
 
 class ApiResponseError extends Error {
-  constructor(message, userMessage = GENERIC_ERROR_MESSAGE) {
+  constructor(message, userMessage = GENERIC_ERROR_MESSAGE, options = {}) {
     super(message);
     this.name = 'ApiResponseError';
     this.userMessage = userMessage;
+    this.status = options.status;
+    this.cause = options.cause;
   }
 }
 
@@ -29,26 +32,73 @@ function toFriendlyErrorMessage(error) {
   return GENERIC_ERROR_MESSAGE;
 }
 
-async function parseApiResponse(response, options = {}) {
-  const { showErrorToast } = options;
-
+async function readResponseBody(response) {
   try {
     if (isEmptyResponseBody(response)) {
       throw new ApiResponseError('API response was empty', EMPTY_RESPONSE_MESSAGE);
     }
 
-    const data =
-      response && typeof response.json === 'function'
-        ? await response.json()
-        : response;
+    if (typeof response.json === 'function') {
+      const data = await response.json();
 
-    if (isEmptyResponseBody(data)) {
+      if (isEmptyResponseBody(data)) {
+        throw new ApiResponseError(
+          'API response body was empty',
+          EMPTY_RESPONSE_MESSAGE
+        );
+      }
+
+      return data;
+    }
+
+    if (typeof response.text === 'function') {
+      const data = await response.text();
+
+      if (isEmptyResponseBody(data)) {
+        throw new ApiResponseError(
+          'API response text body was empty',
+          EMPTY_RESPONSE_MESSAGE
+        );
+      }
+
+      return data;
+    }
+
+    return response;
+  } catch (error) {
+    if (
+      error instanceof SyntaxError &&
+      error.message.includes('Unexpected end of JSON input')
+    ) {
       throw new ApiResponseError(
         'API response body was empty',
-        EMPTY_RESPONSE_MESSAGE
+        EMPTY_RESPONSE_MESSAGE,
+        { cause: error }
       );
     }
 
+    throw error;
+  }
+}
+
+async function safeApiRequest(requestOrResponse, options = {}) {
+  const { showErrorToast } = options;
+
+  try {
+    const response =
+      typeof requestOrResponse === 'function'
+        ? await requestOrResponse()
+        : await requestOrResponse;
+
+    if (response && response.ok === false) {
+      throw new ApiResponseError(
+        `API request failed with status ${response.status || 'unknown'}`,
+        HTTP_ERROR_MESSAGE,
+        { status: response.status }
+      );
+    }
+
+    const data = await readResponseBody(response);
     return { ok: true, data };
   } catch (error) {
     const message = toFriendlyErrorMessage(error);
@@ -65,6 +115,9 @@ module.exports = {
   ApiResponseError,
   EMPTY_RESPONSE_MESSAGE,
   GENERIC_ERROR_MESSAGE,
-  parseApiResponse,
+  HTTP_ERROR_MESSAGE,
+  parseApiResponse: safeApiRequest,
+  readResponseBody,
+  safeApiRequest,
   toFriendlyErrorMessage,
 };

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -1,0 +1,70 @@
+const EMPTY_RESPONSE_MESSAGE =
+  'The server returned an empty response. Please try again.';
+const GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+
+class ApiResponseError extends Error {
+  constructor(message, userMessage = GENERIC_ERROR_MESSAGE) {
+    super(message);
+    this.name = 'ApiResponseError';
+    this.userMessage = userMessage;
+  }
+}
+
+function isEmptyResponseBody(value) {
+  return value === null || value === undefined || value === '';
+}
+
+function toFriendlyErrorMessage(error) {
+  if (error instanceof ApiResponseError) {
+    return error.userMessage;
+  }
+
+  if (
+    error instanceof SyntaxError &&
+    error.message.includes('Unexpected end of JSON input')
+  ) {
+    return EMPTY_RESPONSE_MESSAGE;
+  }
+
+  return GENERIC_ERROR_MESSAGE;
+}
+
+async function parseApiResponse(response, options = {}) {
+  const { showErrorToast } = options;
+
+  try {
+    if (isEmptyResponseBody(response)) {
+      throw new ApiResponseError('API response was empty', EMPTY_RESPONSE_MESSAGE);
+    }
+
+    const data =
+      response && typeof response.json === 'function'
+        ? await response.json()
+        : response;
+
+    if (isEmptyResponseBody(data)) {
+      throw new ApiResponseError(
+        'API response body was empty',
+        EMPTY_RESPONSE_MESSAGE
+      );
+    }
+
+    return { ok: true, data };
+  } catch (error) {
+    const message = toFriendlyErrorMessage(error);
+
+    if (typeof showErrorToast === 'function') {
+      showErrorToast(message);
+    }
+
+    return { ok: false, error: message };
+  }
+}
+
+module.exports = {
+  ApiResponseError,
+  EMPTY_RESPONSE_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+  parseApiResponse,
+  toFriendlyErrorMessage,
+};

--- a/test/api-client.test.js
+++ b/test/api-client.test.js
@@ -1,7 +1,10 @@
 const assert = require('assert');
 const {
   EMPTY_RESPONSE_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+  HTTP_ERROR_MESSAGE,
   parseApiResponse,
+  toFriendlyErrorMessage,
 } = require('../src/api-client');
 
 async function run() {
@@ -56,10 +59,39 @@ async function run() {
   });
   assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
 
+  toasts = [];
+  const emptyTextResult = await parseApiResponse(
+    { text: async () => '' },
+    { showErrorToast: message => toasts.push(message) }
+  );
+
+  assert.deepStrictEqual(emptyTextResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
+
   const validResult = await parseApiResponse({ json: async () => ({ id: 123 }) });
   assert.deepStrictEqual(validResult, {
     ok: true,
     data: { id: 123 },
+  });
+
+  const requestFunctionResult = await parseApiResponse(async () => ({
+    ok: true,
+    json: async () => ({ id: 456, status: 'ready' }),
+  }));
+  assert.deepStrictEqual(requestFunctionResult, {
+    ok: true,
+    data: { id: 456, status: 'ready' },
+  });
+
+  const promiseResult = await parseApiResponse(
+    Promise.resolve({ ok: true, json: async () => [1, 2, 3] })
+  );
+  assert.deepStrictEqual(promiseResult, {
+    ok: true,
+    data: [1, 2, 3],
   });
 
   const falsyNumberResult = await parseApiResponse(0);
@@ -73,6 +105,29 @@ async function run() {
     ok: true,
     data: false,
   });
+
+  const httpErrorResult = await parseApiResponse({
+    ok: false,
+    status: 503,
+    json: async () => ({ error: 'unavailable' }),
+  });
+  assert.deepStrictEqual(httpErrorResult, {
+    ok: false,
+    error: HTTP_ERROR_MESSAGE,
+  });
+
+  const unexpectedErrorResult = await parseApiResponse(() => {
+    throw new Error('network exploded');
+  });
+  assert.deepStrictEqual(unexpectedErrorResult, {
+    ok: false,
+    error: GENERIC_ERROR_MESSAGE,
+  });
+
+  assert.strictEqual(
+    toFriendlyErrorMessage(new SyntaxError('Unexpected end of JSON input')),
+    EMPTY_RESPONSE_MESSAGE
+  );
 
   console.log('API client tests passed');
 }

--- a/test/api-client.test.js
+++ b/test/api-client.test.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+const {
+  EMPTY_RESPONSE_MESSAGE,
+  parseApiResponse,
+} = require('../src/api-client');
+
+async function run() {
+  let toasts = [];
+
+  const nullResult = await parseApiResponse(null, {
+    showErrorToast: message => toasts.push(message),
+  });
+
+  assert.deepStrictEqual(nullResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
+
+  toasts = [];
+  const undefinedResult = await parseApiResponse(undefined, {
+    showErrorToast: message => toasts.push(message),
+  });
+
+  assert.deepStrictEqual(undefinedResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
+
+  toasts = [];
+  const invalidJsonResult = await parseApiResponse(
+    {
+      json: async () => {
+        throw new SyntaxError('Unexpected end of JSON input');
+      },
+    },
+    { showErrorToast: message => toasts.push(message) }
+  );
+
+  assert.deepStrictEqual(invalidJsonResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
+
+  toasts = [];
+  const emptyBodyResult = await parseApiResponse(
+    { json: async () => '' },
+    { showErrorToast: message => toasts.push(message) }
+  );
+
+  assert.deepStrictEqual(emptyBodyResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
+
+  const validResult = await parseApiResponse({ json: async () => ({ id: 123 }) });
+  assert.deepStrictEqual(validResult, {
+    ok: true,
+    data: { id: 123 },
+  });
+
+  const falsyNumberResult = await parseApiResponse(0);
+  assert.deepStrictEqual(falsyNumberResult, {
+    ok: true,
+    data: 0,
+  });
+
+  const falsyBooleanResult = await parseApiResponse(false);
+  assert.deepStrictEqual(falsyBooleanResult, {
+    ok: true,
+    data: false,
+  });
+
+  console.log('API client tests passed');
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a small API response helper that safely handles null, undefined, empty JSON bodies, and empty text bodies
- convert empty-body parse failures and HTTP failure responses into friendly user-facing errors
- support direct responses, promise-based inputs, and function-based request wrappers without crashing
- expand Node test coverage for null/undefined inputs, empty JSON/text bodies, HTTP errors, promise/function requests, and valid falsy payloads

## Why
Issue #35 reports crashes when an API call returns an empty response body. This keeps the fix focused and dependency-free while covering the main response shapes maintainers are likely to hit.

## Verification
- `npm test`

## BountyPay Claim

| Field | Value |
|-------|-------|
| Bounty | $50 USD1 |
| Wallet | `0x103bd928457d1f61227708ee9e2f4cedc0757725` |
| Agent | codex |

Fixes #35
/claim #35
