### PR TITLE
fix: handle empty api responses safely

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-client.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const EMPTY_RESPONSE_MESSAGE =
+  'The server returned an empty response. Please try again.';
+const GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+const HTTP_ERROR_MESSAGE = 'The server request failed. Please try again.';
+
+class ApiResponseError extends Error {
+  constructor(message, userMessage = GENERIC_ERROR_MESSAGE, options = {}) {
+    super(message);
+    this.name = 'ApiResponseError';
+    this.userMessage = userMessage;
+    this.status = options.status;
+    this.cause = options.cause;
+  }
+}
+
+function isEmptyPayload(value) {
+  return value === null || value === undefined || value === '';
+}
+
+function friendlyMessageFor(error) {
+  if (error instanceof ApiResponseError) {
+    return error.userMessage;
+  }
+
+  if (
+    error instanceof SyntaxError &&
+    /unexpected end of json input/i.test(error.message)
+  ) {
+    return EMPTY_RESPONSE_MESSAGE;
+  }
+
+  return GENERIC_ERROR_MESSAGE;
+}
+
+async function readResponseBody(response) {
+  if (isEmptyPayload(response)) {
+    throw new ApiResponseError('API response object was empty', EMPTY_RESPONSE_MESSAGE);
+  }
+
+  if (typeof response.json === 'function') {
+    try {
+      const json = await response.json();
+      if (isEmptyPayload(json)) {
+        throw new ApiResponseError('API response JSON body was empty', EMPTY_RESPONSE_MESSAGE);
+      }
+      return json;
+    } catch (error) {
+      if (error instanceof ApiResponseError) {
+        throw error;
+      }
+
+      if (
+        error instanceof SyntaxError &&
+        /unexpected end of json input/i.test(error.message)
+      ) {
+        throw new ApiResponseError(
+          'API response JSON body was empty or invalid',
+          EMPTY_RESPONSE_MESSAGE,
+          { cause: error }
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  if (typeof response.text === 'function') {
+    const text = await response.text();
+    if (isEmptyPayload(text)) {
+      throw new ApiResponseError('API response text body was empty', EMPTY_RESPONSE_MESSAGE);
+    }
+    return text;
+  }
+
+  if (isEmptyPayload(response)) {
+    throw new ApiResponseError('API response body was empty', EMPTY_RESPONSE_MESSAGE);
+  }
+
+  return response;
+}
+
+async function safeApiRequest(requestOrResponse, options = {}) {
+  const { showErrorToast } = options;
+
+  try {
+    const response =
+      typeof requestOrResponse === 'function'
+        ? await requestOrResponse()
+        : await requestOrResponse;
+
+    if (response && response.ok === false) {
+      throw new ApiResponseError(
+        `API request failed with status ${response.status || 'unknown'}`,
+        HTTP_ERROR_MESSAGE,
+        { status: response.status }
+      );
+    }
+
+    const data = await readResponseBody(response);
+    return { ok: true, data };
+  } catch (error) {
+    const message = friendlyMessageFor(error);
+
+    if (typeof showErrorToast === 'function') {
+      showErrorToast(message);
+    }
+
+    return { ok: false, error: message };
+  }
+}
+
+module.exports = {
+  ApiResponseError,
+  EMPTY_RESPONSE_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+  HTTP_ERROR_MESSAGE,
+  friendlyMessageFor,
+  readResponseBody,
+  safeApiRequest,
+};

--- a/test/api-client.test.js
+++ b/test/api-client.test.js
@@ -1,0 +1,115 @@
+const assert = require('assert');
+const {
+  EMPTY_RESPONSE_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+  HTTP_ERROR_MESSAGE,
+  friendlyMessageFor,
+  safeApiRequest,
+} = require('../src/api-client');
+
+async function run() {
+  const toasts = [];
+
+  const nullResult = await safeApiRequest(null, {
+    showErrorToast: message => toasts.push(message),
+  });
+  assert.deepStrictEqual(nullResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(toasts, [EMPTY_RESPONSE_MESSAGE]);
+
+  const undefinedResult = await safeApiRequest(undefined);
+  assert.deepStrictEqual(undefinedResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const emptyStringJsonResult = await safeApiRequest({
+    ok: true,
+    json: async () => '',
+  });
+  assert.deepStrictEqual(emptyStringJsonResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const emptyJsonParseResult = await safeApiRequest({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    },
+  });
+  assert.deepStrictEqual(emptyJsonParseResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const emptyTextResult = await safeApiRequest({
+    ok: true,
+    text: async () => '',
+  });
+  assert.deepStrictEqual(emptyTextResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const httpErrorResult = await safeApiRequest({
+    ok: false,
+    status: 503,
+    json: async () => ({ error: 'unavailable' }),
+  });
+  assert.deepStrictEqual(httpErrorResult, {
+    ok: false,
+    error: HTTP_ERROR_MESSAGE,
+  });
+
+  const requestFunctionResult = await safeApiRequest(async () => ({
+    ok: true,
+    json: async () => ({ id: 123, status: 'ready' }),
+  }));
+  assert.deepStrictEqual(requestFunctionResult, {
+    ok: true,
+    data: { id: 123, status: 'ready' },
+  });
+
+  const promiseResult = await safeApiRequest(
+    Promise.resolve({ ok: true, json: async () => [1, 2, 3] })
+  );
+  assert.deepStrictEqual(promiseResult, {
+    ok: true,
+    data: [1, 2, 3],
+  });
+
+  const directFalsyNumberResult = await safeApiRequest(0);
+  assert.deepStrictEqual(directFalsyNumberResult, {
+    ok: true,
+    data: 0,
+  });
+
+  const directFalsyBooleanResult = await safeApiRequest(false);
+  assert.deepStrictEqual(directFalsyBooleanResult, {
+    ok: true,
+    data: false,
+  });
+
+  const unexpectedResult = await safeApiRequest(() => {
+    throw new Error('network exploded');
+  });
+  assert.deepStrictEqual(unexpectedResult, {
+    ok: false,
+    error: GENERIC_ERROR_MESSAGE,
+  });
+
+  assert.strictEqual(
+    friendlyMessageFor(new SyntaxError('Unexpected end of JSON input')),
+    EMPTY_RESPONSE_MESSAGE
+  );
+
+  console.log('api-client tests passed');
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a small API response helper that safely handles empty/null/undefined responses without crashing.
- Convert empty JSON bodies and `Unexpected end of JSON input` failures into a friendly user-facing error.
- Add coverage for null/undefined responses, empty JSON/text bodies, HTTP errors, promise/function request inputs, and valid falsy payloads.

## Test Plan
- `npm test`

/claim #35
Fixes #35
agentpay-wallet: 0x697531023a0b0143fbd5ED42226360f2541557c6
