### PR TITLE
Handle empty API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ The CSV parser does not handle Chinese full-width commas (U+FF0C `，`). See Iss
 ## Error Handling
 Added proper timeout handling for all API calls.
 // Webhook integration implemented
+
+`src/api-response.js` provides a shared wrapper for API calls that treats null,
+undefined, and empty response bodies as recoverable failures and surfaces a
+friendly toast message instead of letting callers crash on the response shape.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,152 @@
+/**
+ * Shared API response handling utilities.
+ */
+
+const EMPTY_RESPONSE_MESSAGE = 'The server returned an empty response. Please try again.';
+const REQUEST_FAILED_MESSAGE = 'The server request failed. Please try again.';
+const GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+
+class ApiResponseError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'ApiResponseError';
+    this.code = options.code || 'API_RESPONSE_ERROR';
+    this.status = options.status;
+    this.userMessage = options.userMessage || GENERIC_ERROR_MESSAGE;
+    this.cause = options.cause;
+  }
+}
+
+function isEmptyResponse(value) {
+  return value === null || value === undefined || value === '';
+}
+
+function isEmptyJsonSyntaxError(error) {
+  return error instanceof SyntaxError && /unexpected end of json input/i.test(error.message);
+}
+
+function showFriendlyToast(toast, message) {
+  if (typeof toast === 'function') {
+    toast(message);
+    return;
+  }
+
+  if (toast && typeof toast.error === 'function') {
+    toast.error(message);
+  }
+}
+
+function toUserMessage(error) {
+  if (error instanceof ApiResponseError) {
+    return error.userMessage;
+  }
+
+  if (isEmptyJsonSyntaxError(error)) {
+    return EMPTY_RESPONSE_MESSAGE;
+  }
+
+  return GENERIC_ERROR_MESSAGE;
+}
+
+function parseBodyText(text, response) {
+  if (isEmptyResponse(text)) {
+    throw new ApiResponseError('API response body was empty', {
+      code: 'EMPTY_RESPONSE',
+      status: response && response.status,
+      userMessage: EMPTY_RESPONSE_MESSAGE,
+    });
+  }
+
+  const contentType =
+    typeof response.headers?.get === 'function' ? response.headers.get('content-type') : '';
+
+  if (/json/i.test(contentType) || /^[\[{]/.test(text.trim())) {
+    return JSON.parse(text);
+  }
+
+  return text;
+}
+
+async function readApiResponse(response) {
+  if (isEmptyResponse(response)) {
+    throw new ApiResponseError('API response was empty', {
+      code: 'EMPTY_RESPONSE',
+      userMessage: EMPTY_RESPONSE_MESSAGE,
+    });
+  }
+
+  if (response && response.ok === false) {
+    throw new ApiResponseError(`API request failed with status ${response.status || 'unknown'}`, {
+      code: 'REQUEST_FAILED',
+      status: response.status,
+      userMessage: REQUEST_FAILED_MESSAGE,
+    });
+  }
+
+  if (typeof response.text === 'function') {
+    return parseBodyText(await response.text(), response);
+  }
+
+  if (typeof response.json === 'function') {
+    try {
+      const data = await response.json();
+
+      if (isEmptyResponse(data)) {
+        throw new ApiResponseError('API JSON response body was empty', {
+          code: 'EMPTY_RESPONSE',
+          status: response.status,
+          userMessage: EMPTY_RESPONSE_MESSAGE,
+        });
+      }
+
+      return data;
+    } catch (error) {
+      if (isEmptyJsonSyntaxError(error)) {
+        throw new ApiResponseError('API JSON response body was empty', {
+          code: 'EMPTY_RESPONSE',
+          status: response.status,
+          userMessage: EMPTY_RESPONSE_MESSAGE,
+          cause: error,
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  return response;
+}
+
+async function requestWithFriendlyErrors(requestOrResponse, options = {}) {
+  try {
+    const response =
+      typeof requestOrResponse === 'function'
+        ? await requestOrResponse()
+        : await requestOrResponse;
+
+    return {
+      ok: true,
+      data: await readApiResponse(response),
+    };
+  } catch (error) {
+    const message = toUserMessage(error);
+    showFriendlyToast(options.toast || options.showErrorToast, message);
+
+    return {
+      ok: false,
+      error: message,
+    };
+  }
+}
+
+module.exports = {
+  ApiResponseError,
+  EMPTY_RESPONSE_MESSAGE,
+  REQUEST_FAILED_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+  isEmptyResponse,
+  readApiResponse,
+  requestWithFriendlyErrors,
+  showFriendlyToast,
+  toUserMessage,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,129 @@
+const assert = require('assert');
+const {
+  EMPTY_RESPONSE_MESSAGE,
+  GENERIC_ERROR_MESSAGE,
+  REQUEST_FAILED_MESSAGE,
+  readApiResponse,
+  requestWithFriendlyErrors,
+  toUserMessage,
+} = require('../src/api-response');
+
+async function run() {
+  const functionToasts = [];
+
+  const nullResult = await requestWithFriendlyErrors(null, {
+    showErrorToast: message => functionToasts.push(message),
+  });
+
+  assert.deepStrictEqual(nullResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert.deepStrictEqual(functionToasts, [EMPTY_RESPONSE_MESSAGE]);
+
+  const undefinedResult = await requestWithFriendlyErrors(undefined);
+  assert.deepStrictEqual(undefinedResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const emptyJsonResult = await requestWithFriendlyErrors({
+    ok: true,
+    json: async () => null,
+  });
+  assert.deepStrictEqual(emptyJsonResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const emptyJsonParseResult = await requestWithFriendlyErrors({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    },
+  });
+  assert.deepStrictEqual(emptyJsonParseResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const emptyTextResult = await requestWithFriendlyErrors({
+    ok: true,
+    text: async () => '',
+  });
+  assert.deepStrictEqual(emptyTextResult, {
+    ok: false,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const objectToast = {
+    messages: [],
+    error(message) {
+      this.messages.push(message);
+    },
+  };
+  const httpErrorResult = await requestWithFriendlyErrors(
+    { ok: false, status: 503, text: async () => '{"error":"down"}' },
+    { toast: objectToast }
+  );
+  assert.deepStrictEqual(httpErrorResult, {
+    ok: false,
+    error: REQUEST_FAILED_MESSAGE,
+  });
+  assert.deepStrictEqual(objectToast.messages, [REQUEST_FAILED_MESSAGE]);
+
+  const parsedJson = await readApiResponse({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    text: async () => '{"id":123,"status":"ready"}',
+  });
+  assert.deepStrictEqual(parsedJson, { id: 123, status: 'ready' });
+
+  const plainText = await readApiResponse({
+    ok: true,
+    headers: { get: () => 'text/plain' },
+    text: async () => 'ready',
+  });
+  assert.strictEqual(plainText, 'ready');
+
+  const requestFunctionResult = await requestWithFriendlyErrors(async () => ({
+    ok: true,
+    json: async () => ({ id: 456 }),
+  }));
+  assert.deepStrictEqual(requestFunctionResult, {
+    ok: true,
+    data: { id: 456 },
+  });
+
+  const zeroResult = await requestWithFriendlyErrors(0);
+  assert.deepStrictEqual(zeroResult, {
+    ok: true,
+    data: 0,
+  });
+
+  const falseResult = await requestWithFriendlyErrors(false);
+  assert.deepStrictEqual(falseResult, {
+    ok: true,
+    data: false,
+  });
+
+  const unexpectedErrorResult = await requestWithFriendlyErrors(() => {
+    throw new Error('network exploded');
+  });
+  assert.deepStrictEqual(unexpectedErrorResult, {
+    ok: false,
+    error: GENERIC_ERROR_MESSAGE,
+  });
+
+  assert.strictEqual(
+    toUserMessage(new SyntaxError('Unexpected end of JSON input')),
+    EMPTY_RESPONSE_MESSAGE
+  );
+
+  console.log('api-response tests passed');
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
/claim #35

Fixes #35.

## What changed
- Added a shared API response helper for null, undefined, empty text bodies, and empty JSON bodies.
- Converted those cases into a friendly user-facing error instead of letting callers crash on the response shape.
- Supports both `showErrorToast(message)` and `toast.error(message)` call styles.
- Preserves valid falsy payloads such as `0` and `false`.

## Verification
- `npm test`

## Payout
Payment method: BountyPay/USD1 payout on BSC.
BountyPay/USD1 wallet: `0xEA102cf5930eec97b0D39B916F82a46eAeA5f1B7`
Network: BSC
