### PR TITLE
Handle empty API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,91 @@
+const EMPTY_RESPONSE_MESSAGE = 'No data was returned. Please try again later.';
+const REQUEST_FAILED_MESSAGE = 'Unable to load data. Please try again later.';
+
+function isResponseLike(value) {
+  return Boolean(value && typeof value === 'object' && (
+    typeof value.json === 'function' ||
+    typeof value.text === 'function' ||
+    'ok' in value ||
+    'status' in value
+  ));
+}
+
+function isEmptyPayload(value) {
+  return value == null || (typeof value === 'string' && value.trim() === '');
+}
+
+function notifyError(notifier, message) {
+  if (!notifier) return;
+
+  if (typeof notifier === 'function') {
+    notifier(message);
+    return;
+  }
+
+  if (typeof notifier.showErrorToast === 'function') {
+    notifier.showErrorToast(message);
+    return;
+  }
+
+  if (typeof notifier.error === 'function') {
+    notifier.error(message);
+  }
+}
+
+function success(data) {
+  return { ok: true, data, error: null };
+}
+
+function failure(message, notifier) {
+  notifyError(notifier, message);
+  return { ok: false, data: null, error: message };
+}
+
+async function readResponseBody(response) {
+  if (typeof response.json === 'function') {
+    try {
+      return await response.json();
+    } catch (error) {
+      if (error instanceof SyntaxError) return null;
+      throw error;
+    }
+  }
+
+  if (typeof response.text === 'function') {
+    return response.text();
+  }
+
+  return response;
+}
+
+async function handleApiResponse(responseOrPromise, options = {}) {
+  const response = await responseOrPromise;
+  const notifier = options.toast || options.notifier || options.onError;
+
+  if (isEmptyPayload(response)) {
+    return failure(EMPTY_RESPONSE_MESSAGE, notifier);
+  }
+
+  if (isResponseLike(response)) {
+    if (response.ok === false) {
+      return failure(REQUEST_FAILED_MESSAGE, notifier);
+    }
+
+    const body = await readResponseBody(response);
+    if (isEmptyPayload(body)) {
+      return failure(EMPTY_RESPONSE_MESSAGE, notifier);
+    }
+
+    return success(body);
+  }
+
+  return success(response);
+}
+
+module.exports = {
+  EMPTY_RESPONSE_MESSAGE,
+  REQUEST_FAILED_MESSAGE,
+  handleApiResponse,
+  isEmptyPayload,
+  notifyError,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,108 @@
+const {
+  EMPTY_RESPONSE_MESSAGE,
+  REQUEST_FAILED_MESSAGE,
+  handleApiResponse,
+  isEmptyPayload,
+} = require('../src/api-response');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  PASS ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+async function run() {
+  console.log('\nAPI Response Tests\n');
+
+  assert('detects null payloads as empty', isEmptyPayload(null), true);
+  assert('detects undefined payloads as empty', isEmptyPayload(undefined), true);
+  assert('detects blank text payloads as empty', isEmptyPayload('   '), true);
+  assert('keeps false as a valid payload', isEmptyPayload(false), false);
+  assert('keeps zero as a valid payload', isEmptyPayload(0), false);
+
+  const toastMessages = [];
+  const nullResult = await handleApiResponse(null, {
+    toast: { error: message => toastMessages.push(message) },
+  });
+
+  assert('null API response returns a friendly failure', nullResult, {
+    ok: false,
+    data: null,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+  assert('null API response shows an error toast', toastMessages, [
+    EMPTY_RESPONSE_MESSAGE,
+  ]);
+
+  const emptyJsonResult = await handleApiResponse({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    },
+  });
+
+  assert('empty JSON body returns a friendly failure', emptyJsonResult, {
+    ok: false,
+    data: null,
+    error: EMPTY_RESPONSE_MESSAGE,
+  });
+
+  const httpFailureToast = [];
+  const httpFailureResult = await handleApiResponse({
+    ok: false,
+    status: 500,
+    json: async () => ({ message: 'internal error' }),
+  }, {
+    onError: message => httpFailureToast.push(message),
+  });
+
+  assert('HTTP failures return a friendly failure', httpFailureResult, {
+    ok: false,
+    data: null,
+    error: REQUEST_FAILED_MESSAGE,
+  });
+  assert('HTTP failures show an error toast', httpFailureToast, [
+    REQUEST_FAILED_MESSAGE,
+  ]);
+
+  const validJsonResult = await handleApiResponse({
+    ok: true,
+    json: async () => ({ items: [1, 2, 3] }),
+  });
+
+  assert('valid JSON response passes through', validJsonResult, {
+    ok: true,
+    data: { items: [1, 2, 3] },
+    error: null,
+  });
+
+  const falseResult = await handleApiResponse({
+    ok: true,
+    json: async () => false,
+  });
+
+  assert('valid falsy JSON response passes through', falseResult, {
+    ok: true,
+    data: false,
+    error: null,
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a small API response helper for null, undefined, empty text, and empty JSON responses
- return a friendly failure result and call toast-style error notifiers instead of crashing
- add regression tests for empty responses, HTTP failures, toast callbacks, valid JSON, and valid falsy JSON

## Verification
- Not run locally: Node/npm are not installed in this environment. GitHub Actions should run npm test on the PR.

Fixes #35