### PR TITLE
Fix empty API response handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,48 @@
+const DEFAULT_ERROR_MESSAGE = 'Unable to load data. Please try again later.';
+
+function createErrorToast(message = DEFAULT_ERROR_MESSAGE) {
+  return {
+    type: 'error',
+    message,
+  };
+}
+
+function parseApiResponse(body, options = {}) {
+  const errorMessage = options.errorMessage || DEFAULT_ERROR_MESSAGE;
+
+  if (body === null || body === undefined || body === '') {
+    return {
+      ok: false,
+      data: null,
+      toast: createErrorToast(errorMessage),
+    };
+  }
+
+  if (typeof body === 'string') {
+    try {
+      return {
+        ok: true,
+        data: JSON.parse(body),
+        toast: null,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        data: null,
+        toast: createErrorToast(errorMessage),
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    data: body,
+    toast: null,
+  };
+}
+
+module.exports = {
+  DEFAULT_ERROR_MESSAGE,
+  createErrorToast,
+  parseApiResponse,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,83 @@
+const { parseApiResponse, DEFAULT_ERROR_MESSAGE } = require('../src/api-response');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  PASS ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+console.log('\nAPI Response Tests\n');
+
+assert(
+  'handles null response with friendly error toast',
+  parseApiResponse(null),
+  {
+    ok: false,
+    data: null,
+    toast: { type: 'error', message: DEFAULT_ERROR_MESSAGE },
+  }
+);
+
+assert(
+  'handles undefined response with friendly error toast',
+  parseApiResponse(undefined),
+  {
+    ok: false,
+    data: null,
+    toast: { type: 'error', message: DEFAULT_ERROR_MESSAGE },
+  }
+);
+
+assert(
+  'handles empty response body with friendly error toast',
+  parseApiResponse(''),
+  {
+    ok: false,
+    data: null,
+    toast: { type: 'error', message: DEFAULT_ERROR_MESSAGE },
+  }
+);
+
+assert(
+  'parses valid JSON response body',
+  parseApiResponse('{"bounties":[{"id":35}]}'),
+  {
+    ok: true,
+    data: { bounties: [{ id: 35 }] },
+    toast: null,
+  }
+);
+
+assert(
+  'returns object responses unchanged',
+  parseApiResponse({ bounties: [] }),
+  {
+    ok: true,
+    data: { bounties: [] },
+    toast: null,
+  }
+);
+
+assert(
+  'uses custom friendly error message',
+  parseApiResponse(null, { errorMessage: 'No bounty data was returned.' }),
+  {
+    ok: false,
+    data: null,
+    toast: { type: 'error', message: 'No bounty data was returned.' },
+  }
+);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #35

## Summary
- Add API response parsing helper for null, undefined, empty, and invalid JSON responses
- Return a friendly error toast instead of allowing crashes
- Add unit coverage for the error handling path

## Tests
- node test/parser.test.js && node test/api-response.test.js