### PR TITLE
Add loading spinner state for bounty list

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/loading-spinner.test.js"
   },
   "license": "MIT"
 }

--- a/src/loading-spinner.js
+++ b/src/loading-spinner.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const DEFAULT_ERROR_MESSAGE = 'Unable to load bounties. Please try again.';
+
+function createLoadingState() {
+  return {
+    isLoading: false,
+    error: null,
+    bounties: [],
+  };
+}
+
+async function loadBounties(fetchBounties, state = createLoadingState()) {
+  if (typeof fetchBounties !== 'function') {
+    throw new TypeError('fetchBounties must be a function');
+  }
+
+  state.isLoading = true;
+  state.error = null;
+
+  try {
+    const bounties = await fetchBounties();
+    state.bounties = Array.isArray(bounties) ? bounties : [];
+    return state;
+  } catch (error) {
+    state.bounties = [];
+    state.error = error && error.message ? error.message : DEFAULT_ERROR_MESSAGE;
+    return state;
+  } finally {
+    state.isLoading = false;
+  }
+}
+
+function renderBountyList(state) {
+  if (state.isLoading) {
+    return '<div class="loading-spinner" role="status" aria-live="polite"><span class="spinner" aria-hidden="true"></span>Loading bounties...</div>';
+  }
+
+  if (state.error) {
+    return `<div class="error-state" role="alert">${escapeHtml(state.error)}</div>`;
+  }
+
+  if (!state.bounties.length) {
+    return '<p class="empty-state">No bounties available.</p>';
+  }
+
+  const items = state.bounties
+    .map((bounty) => `<li>${escapeHtml(String(bounty.title || bounty))}</li>`)
+    .join('');
+
+  return `<ul class="bounty-list">${items}</ul>`;
+}
+
+function escapeHtml(value) {
+  return value.replace(/[&<>'"]/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    "'": '&#39;',
+    '"': '&quot;',
+  }[char]));
+}
+
+module.exports = {
+  DEFAULT_ERROR_MESSAGE,
+  createLoadingState,
+  loadBounties,
+  renderBountyList,
+};

--- a/src/loading-spinner.js
+++ b/src/loading-spinner.js
@@ -7,6 +7,7 @@ function createLoadingState() {
     isLoading: false,
     error: null,
     bounties: [],
+    requestId: 0,
   };
 }
 
@@ -15,20 +16,41 @@ async function loadBounties(fetchBounties, state = createLoadingState()) {
     throw new TypeError('fetchBounties must be a function');
   }
 
+  const requestId = state.requestId + 1;
+  state.requestId = requestId;
   state.isLoading = true;
   state.error = null;
 
   try {
     const bounties = await fetchBounties();
+    if (state.requestId !== requestId) {
+      return state;
+    }
     state.bounties = Array.isArray(bounties) ? bounties : [];
     return state;
   } catch (error) {
-    state.bounties = [];
-    state.error = error && error.message ? error.message : DEFAULT_ERROR_MESSAGE;
+    if (state.requestId !== requestId) {
+      return state;
+    }
+    state.error = toUserSafeError(error);
     return state;
   } finally {
-    state.isLoading = false;
+    if (state.requestId === requestId) {
+      state.isLoading = false;
+    }
   }
+}
+
+async function updateBountyList(container, fetchBounties, state = createLoadingState()) {
+  if (!container || typeof container !== 'object') {
+    throw new TypeError('container must be a DOM element-like object');
+  }
+
+  const pending = loadBounties(fetchBounties, state);
+  container.innerHTML = renderBountyList(state);
+  await pending;
+  container.innerHTML = renderBountyList(state);
+  return state;
 }
 
 function renderBountyList(state) {
@@ -51,6 +73,13 @@ function renderBountyList(state) {
   return `<ul class="bounty-list">${items}</ul>`;
 }
 
+function toUserSafeError(error) {
+  if (error && error.userMessage) {
+    return String(error.userMessage);
+  }
+  return DEFAULT_ERROR_MESSAGE;
+}
+
 function escapeHtml(value) {
   return value.replace(/[&<>'"]/g, (char) => ({
     '&': '&amp;',
@@ -66,4 +95,5 @@ module.exports = {
   createLoadingState,
   loadBounties,
   renderBountyList,
+  updateBountyList,
 };

--- a/test/loading-spinner.test.js
+++ b/test/loading-spinner.test.js
@@ -1,4 +1,10 @@
-const { createLoadingState, loadBounties, renderBountyList } = require('../src/loading-spinner');
+const {
+  DEFAULT_ERROR_MESSAGE,
+  createLoadingState,
+  loadBounties,
+  renderBountyList,
+  updateBountyList,
+} = require('../src/loading-spinner');
 
 let passed = 0;
 let failed = 0;
@@ -17,6 +23,14 @@ function assert(name, actual, expected) {
   }
 }
 
+function defer() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 async function run() {
   console.log('\nLoading Spinner Tests\n');
 
@@ -31,10 +45,37 @@ async function run() {
   assert('renders accessible loading status', loadingMarkup.includes('role="status"'), true);
   assert('renders spinner class while loading', loadingMarkup.includes('loading-spinner'), true);
 
-  const errorState = await loadBounties(() => Promise.reject(new Error('Network failed')));
+  const errorState = await loadBounties(() => Promise.reject(new Error('internal host 10.0.0.5 failed')));
   assert('clears loading after failed API call', errorState.isLoading, false);
-  assert('stores error message', errorState.error, 'Network failed');
+  assert('stores safe default error message', errorState.error, DEFAULT_ERROR_MESSAGE);
   assert('renders error alert', renderBountyList(errorState).includes('role="alert"'), true);
+
+  const safeError = new Error('internal detail');
+  safeError.userMessage = 'Could not refresh bounty list.';
+  const safeErrorState = await loadBounties(() => Promise.reject(safeError));
+  assert('allows explicit user-facing errors', safeErrorState.error, 'Could not refresh bounty list.');
+
+  const staleState = createLoadingState();
+  const slow = defer();
+  const first = loadBounties(() => slow.promise, staleState);
+  const second = await loadBounties(() => Promise.resolve([{ title: 'New result' }]), staleState);
+  slow.resolve([{ title: 'Stale result' }]);
+  await first;
+  assert('keeps latest result when requests overlap', second.bounties, [{ title: 'New result' }]);
+
+  const markup = renderBountyList({
+    isLoading: false,
+    error: null,
+    bounties: [{ title: '<script>alert(1)</script>' }],
+  });
+  assert('escapes bounty titles', markup.includes('&lt;script&gt;alert(1)&lt;/script&gt;'), true);
+
+  const emptyMarkup = renderBountyList({ isLoading: false, error: null, bounties: [] });
+  assert('renders empty state', emptyMarkup.includes('No bounties available.'), true);
+
+  const container = { innerHTML: '' };
+  await updateBountyList(container, () => Promise.resolve([{ title: 'Integrated render' }]));
+  assert('updates a container with final bounty markup', container.innerHTML.includes('Integrated render'), true);
 
   console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);

--- a/test/loading-spinner.test.js
+++ b/test/loading-spinner.test.js
@@ -1,0 +1,43 @@
+const { createLoadingState, loadBounties, renderBountyList } = require('../src/loading-spinner');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  OK ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+async function run() {
+  console.log('\nLoading Spinner Tests\n');
+
+  const state = createLoadingState();
+  const pending = loadBounties(() => Promise.resolve([{ title: 'Fix parser' }]), state);
+  assert('sets loading while API call is pending', state.isLoading, true);
+  await pending;
+  assert('clears loading after API call completes', state.isLoading, false);
+  assert('stores loaded bounties', state.bounties, [{ title: 'Fix parser' }]);
+
+  const loadingMarkup = renderBountyList({ isLoading: true, error: null, bounties: [] });
+  assert('renders accessible loading status', loadingMarkup.includes('role="status"'), true);
+  assert('renders spinner class while loading', loadingMarkup.includes('loading-spinner'), true);
+
+  const errorState = await loadBounties(() => Promise.reject(new Error('Network failed')));
+  assert('clears loading after failed API call', errorState.isLoading, false);
+  assert('stores error message', errorState.error, 'Network failed');
+  assert('renders error alert', renderBountyList(errorState).includes('role="alert"'), true);
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
Fixes #18.

## Changes
- Add a reusable loading-state helper for bounty list API calls.
- Render an accessible spinner/status while a bounty request is pending.
- Render graceful error and empty states.
- Add `updateBountyList(container, fetchBounties)` so the helper can update an actual bounty-list container instead of only returning standalone markup.
- Avoid exposing raw internal error messages unless callers provide an explicit `userMessage`.
- Guard overlapping requests so stale slower responses cannot overwrite newer results.
- Add tests covering loading, success, failure, empty state, HTML escaping, stale-request handling, and container updates.

## Validation
```bash
npm test
```
