### PR TITLE
Add loading and error states to bounty list

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/bountyList.test.js"
   },
   "license": "MIT"
 }

--- a/src/bountyList.js
+++ b/src/bountyList.js
@@ -1,0 +1,135 @@
+const DEFAULT_LOADING_LABEL = 'Loading bounties...';
+
+function createElement(documentRef, tagName, attributes = {}, children = []) {
+  const element = documentRef.createElement(tagName);
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined || value === null) continue;
+
+    if (key === 'className') {
+      element.className = value;
+    } else if (key === 'textContent') {
+      element.textContent = value;
+    } else {
+      element.setAttribute(key, value);
+    }
+  }
+
+  for (const child of children) {
+    element.appendChild(
+      typeof child === 'string' ? documentRef.createTextNode(child) : child
+    );
+  }
+
+  return element;
+}
+
+function renderLoadingState(container, options = {}) {
+  const documentRef = container.ownerDocument;
+  const label = options.loadingLabel || DEFAULT_LOADING_LABEL;
+
+  container.replaceChildren(
+    createElement(documentRef, 'div', {
+      className: 'bounty-list__loading',
+      role: 'status',
+      'aria-live': 'polite',
+      'aria-busy': 'true',
+    }, [
+      createElement(documentRef, 'span', {
+        className: 'bounty-list__spinner',
+        'aria-hidden': 'true',
+      }),
+      createElement(documentRef, 'span', {
+        className: 'bounty-list__loading-label',
+        textContent: label,
+      }),
+    ])
+  );
+}
+
+function renderErrorState(container, error, retry) {
+  const documentRef = container.ownerDocument;
+  const message = error && error.message ? error.message : 'Unable to load bounties.';
+  const children = [
+    createElement(documentRef, 'p', {
+      className: 'bounty-list__error-message',
+      textContent: message,
+    }),
+  ];
+
+  if (typeof retry === 'function') {
+    const retryButton = createElement(documentRef, 'button', {
+      className: 'bounty-list__retry',
+      type: 'button',
+      textContent: 'Try again',
+    });
+    retryButton.addEventListener('click', retry);
+    children.push(retryButton);
+  }
+
+  container.replaceChildren(
+    createElement(documentRef, 'div', {
+      className: 'bounty-list__error',
+      role: 'alert',
+    }, children)
+  );
+}
+
+function renderBounties(container, bounties) {
+  const documentRef = container.ownerDocument;
+
+  if (!Array.isArray(bounties) || bounties.length === 0) {
+    container.replaceChildren(
+      createElement(documentRef, 'p', {
+        className: 'bounty-list__empty',
+        textContent: 'No bounties available.',
+      })
+    );
+    return;
+  }
+
+  const items = bounties.map((bounty) =>
+    createElement(documentRef, 'li', { className: 'bounty-list__item' }, [
+      createElement(documentRef, 'span', {
+        className: 'bounty-list__title',
+        textContent: bounty.title || 'Untitled bounty',
+      }),
+      createElement(documentRef, 'span', {
+        className: 'bounty-list__amount',
+        textContent: bounty.amount ? String(bounty.amount) : 'Unpriced',
+      }),
+    ])
+  );
+
+  container.replaceChildren(
+    createElement(documentRef, 'ul', { className: 'bounty-list' }, items)
+  );
+}
+
+async function loadBountyList(container, fetchBounties, options = {}) {
+  if (!container || !container.ownerDocument) {
+    throw new Error('A DOM container is required');
+  }
+
+  if (typeof fetchBounties !== 'function') {
+    throw new Error('fetchBounties must be a function');
+  }
+
+  renderLoadingState(container, options);
+
+  try {
+    const bounties = await fetchBounties();
+    renderBounties(container, bounties);
+    return bounties;
+  } catch (error) {
+    renderErrorState(container, error, () => loadBountyList(container, fetchBounties, options));
+    return null;
+  }
+}
+
+module.exports = {
+  loadBountyList,
+  renderBounties,
+  renderErrorState,
+  renderLoadingState,
+};

--- a/test/bountyList.test.js
+++ b/test/bountyList.test.js
@@ -1,0 +1,151 @@
+const {
+  loadBountyList,
+  renderBounties,
+  renderErrorState,
+  renderLoadingState,
+} = require('../src/bountyList');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition) {
+  if (condition) {
+    console.log(`  OK ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    failed++;
+  }
+}
+
+class FakeNode {
+  constructor(ownerDocument) {
+    this.ownerDocument = ownerDocument;
+    this.children = [];
+    this.attributes = {};
+    this.listeners = {};
+    this.textContent = '';
+    this.className = '';
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  replaceChildren(...children) {
+    this.children = children;
+  }
+
+  setAttribute(key, value) {
+    this.attributes[key] = String(value);
+  }
+
+  addEventListener(type, callback) {
+    this.listeners[type] = callback;
+  }
+
+  click() {
+    if (this.listeners.click) {
+      this.listeners.click();
+    }
+  }
+
+  getAttribute(key) {
+    return this.attributes[key];
+  }
+}
+
+class FakeTextNode {
+  constructor(text) {
+    this.textContent = text;
+  }
+}
+
+class FakeDocument {
+  createElement() {
+    return new FakeNode(this);
+  }
+
+  createTextNode(text) {
+    return new FakeTextNode(text);
+  }
+}
+
+function createContainer() {
+  return new FakeNode(new FakeDocument());
+}
+
+function findByClass(node, className) {
+  if (!node) return null;
+  if (node.className === className) return node;
+
+  for (const child of node.children || []) {
+    const result = findByClass(child, className);
+    if (result) return result;
+  }
+
+  return null;
+}
+
+function allByClass(node, className, results = []) {
+  if (!node) return results;
+  if (node.className === className) results.push(node);
+
+  for (const child of node.children || []) {
+    allByClass(child, className, results);
+  }
+
+  return results;
+}
+
+(async () => {
+  console.log('\nBounty List Tests\n');
+
+  const loadingContainer = createContainer();
+  renderLoadingState(loadingContainer);
+  const loadingRoot = loadingContainer.children[0];
+  assert('loading state renders status role', loadingRoot.getAttribute('role') === 'status');
+  assert('loading state marks busy content', loadingRoot.getAttribute('aria-busy') === 'true');
+  assert('loading state includes spinner', Boolean(findByClass(loadingRoot, 'bounty-list__spinner')));
+
+  const loadedContainer = createContainer();
+  renderBounties(loadedContainer, [
+    { title: 'Fix spinner', amount: '$50' },
+    { title: 'Add skeleton', amount: '$75' },
+  ]);
+  assert('loaded state renders list items', allByClass(loadedContainer, 'bounty-list__item').length === 2);
+  assert('loaded state includes amount text', findByClass(loadedContainer, 'bounty-list__amount').textContent === '$50');
+
+  const emptyContainer = createContainer();
+  renderBounties(emptyContainer, []);
+  assert('empty state renders fallback copy', findByClass(emptyContainer, 'bounty-list__empty').textContent === 'No bounties available.');
+
+  let retryCount = 0;
+  const errorContainer = createContainer();
+  renderErrorState(errorContainer, new Error('Network down'), () => retryCount++);
+  assert('error state renders alert role', errorContainer.children[0].getAttribute('role') === 'alert');
+  assert('error state shows error message', findByClass(errorContainer, 'bounty-list__error-message').textContent === 'Network down');
+  findByClass(errorContainer, 'bounty-list__retry').click();
+  assert('error retry button calls callback', retryCount === 1);
+
+  const asyncContainer = createContainer();
+  let resolveFetch;
+  const fetchPromise = new Promise((resolve) => {
+    resolveFetch = resolve;
+  });
+  const loadPromise = loadBountyList(asyncContainer, () => fetchPromise);
+  assert('async loader immediately shows spinner', Boolean(findByClass(asyncContainer, 'bounty-list__spinner')));
+  resolveFetch([{ title: 'Async bounty', amount: '$50' }]);
+  const result = await loadPromise;
+  assert('async loader returns fetched bounties', result.length === 1);
+  assert('async loader swaps spinner for data', Boolean(findByClass(asyncContainer, 'bounty-list__title')));
+
+  const failingContainer = createContainer();
+  const failingResult = await loadBountyList(failingContainer, () => Promise.reject(new Error('API failed')));
+  assert('failing loader returns null', failingResult === null);
+  assert('failing loader renders retry action', Boolean(findByClass(failingContainer, 'bounty-list__retry')));
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})();


### PR DESCRIPTION
Closes #18

## Summary
- Adds a reusable bounty list loader that renders a spinner while data is loading.
- Renders bounty items once the fetch resolves.
- Adds empty and error states, including a retry action for failed API calls.
- Adds unit coverage for loading, loaded, empty, error, retry, async success, and async failure flows.

## Test plan
- npm test