### PR TITLE
Handle empty API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,117 @@
+const DEFAULT_API_ERROR_MESSAGE = 'Something went wrong while loading data. Please try again.';
+const EMPTY_API_RESPONSE_MESSAGE = 'No data was returned. Please try again.';
+
+class ApiResponseError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'ApiResponseError';
+    this.userMessage = options.userMessage || DEFAULT_API_ERROR_MESSAGE;
+    this.cause = options.cause;
+  }
+}
+
+function isEmptyString(value) {
+  return typeof value === 'string' && value.trim() === '';
+}
+
+function createEmptyResponseError() {
+  return new ApiResponseError('API response was empty.', {
+    userMessage: EMPTY_API_RESPONSE_MESSAGE,
+  });
+}
+
+async function parseApiResponse(response) {
+  if (response == null || isEmptyString(response)) {
+    throw createEmptyResponseError();
+  }
+
+  if (response.ok === false) {
+    throw new ApiResponseError(`API request failed with status ${response.status || 'unknown'}.`);
+  }
+
+  if (typeof response.json === 'function') {
+    try {
+      const data = await response.json();
+
+      if (data == null || isEmptyString(data)) {
+        throw createEmptyResponseError();
+      }
+
+      return data;
+    } catch (error) {
+      if (error instanceof ApiResponseError) {
+        throw error;
+      }
+
+      throw new ApiResponseError('API response could not be parsed as JSON.', {
+        cause: error,
+      });
+    }
+  }
+
+  if (typeof response.text === 'function') {
+    const body = await response.text();
+
+    if (isEmptyString(body)) {
+      throw createEmptyResponseError();
+    }
+
+    try {
+      return JSON.parse(body);
+    } catch {
+      return body;
+    }
+  }
+
+  return response;
+}
+
+function showErrorToast(toast, message) {
+  if (!toast) {
+    return;
+  }
+
+  if (typeof toast === 'function') {
+    toast(message);
+    return;
+  }
+
+  if (typeof toast.error === 'function') {
+    toast.error(message);
+    return;
+  }
+
+  if (typeof toast.showErrorToast === 'function') {
+    toast.showErrorToast(message);
+  }
+}
+
+async function safeApiCall(request, options = {}) {
+  try {
+    const response = typeof request === 'function' ? await request() : await request;
+    const data = await parseApiResponse(response);
+
+    return { ok: true, data, error: null };
+  } catch (error) {
+    const apiError =
+      error instanceof ApiResponseError
+        ? error
+        : new ApiResponseError(error?.message || DEFAULT_API_ERROR_MESSAGE, {
+            cause: error,
+          });
+    const message = options.errorMessage || apiError.userMessage;
+
+    showErrorToast(options.toast, message);
+
+    return { ok: false, data: null, error: apiError, message };
+  }
+}
+
+module.exports = {
+  ApiResponseError,
+  DEFAULT_API_ERROR_MESSAGE,
+  EMPTY_API_RESPONSE_MESSAGE,
+  parseApiResponse,
+  safeApiCall,
+  showErrorToast,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,90 @@
+const assert = require('assert');
+const {
+  ApiResponseError,
+  EMPTY_API_RESPONSE_MESSAGE,
+  parseApiResponse,
+  safeApiCall,
+  showErrorToast,
+} = require('../src/api-response');
+
+async function assertRejectsEmpty(name, response) {
+  let error;
+
+  try {
+    await parseApiResponse(response);
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error instanceof ApiResponseError, name);
+  assert.equal(error.userMessage, EMPTY_API_RESPONSE_MESSAGE);
+}
+
+async function testHandlesNullUndefinedAndEmptyResponses() {
+  await assertRejectsEmpty('null response is rejected safely', null);
+  await assertRejectsEmpty('undefined response is rejected safely', undefined);
+  await assertRejectsEmpty('empty string response is rejected safely', '  ');
+  await assertRejectsEmpty('empty text body is rejected safely', {
+    ok: true,
+    text: async () => '',
+  });
+  await assertRejectsEmpty('null JSON body is rejected safely', {
+    ok: true,
+    json: async () => null,
+  });
+}
+
+async function testPreservesValidFalsyPayloads() {
+  assert.equal(await parseApiResponse({ ok: true, json: async () => 0 }), 0);
+  assert.equal(await parseApiResponse({ ok: true, json: async () => false }), false);
+}
+
+async function testParsesValidResponses() {
+  assert.deepEqual(await parseApiResponse({ ok: true, json: async () => ({ ok: true }) }), {
+    ok: true,
+  });
+  assert.deepEqual(await parseApiResponse({ ok: true, text: async () => '{"ok":true}' }), {
+    ok: true,
+  });
+  assert.equal(await parseApiResponse({ ok: true, text: async () => 'plain text' }), 'plain text');
+}
+
+async function testSafeApiCallShowsFriendlyToast() {
+  const messages = [];
+  const result = await safeApiCall(async () => null, {
+    toast: (message) => messages.push(message),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.data, null);
+  assert.ok(result.error instanceof ApiResponseError);
+  assert.deepEqual(messages, [EMPTY_API_RESPONSE_MESSAGE]);
+}
+
+function testToastAdapters() {
+  const messages = [];
+
+  showErrorToast((message) => messages.push(`fn:${message}`), 'one');
+  showErrorToast({ error: (message) => messages.push(`error:${message}`) }, 'two');
+  showErrorToast(
+    { showErrorToast: (message) => messages.push(`showErrorToast:${message}`) },
+    'three'
+  );
+
+  assert.deepEqual(messages, ['fn:one', 'error:two', 'showErrorToast:three']);
+}
+
+async function run() {
+  await testHandlesNullUndefinedAndEmptyResponses();
+  await testPreservesValidFalsyPayloads();
+  await testParsesValidResponses();
+  await testSafeApiCallShowsFriendlyToast();
+  testToastAdapters();
+
+  console.log('api-response tests passed');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #35

## Summary
- add a small API response helper for null, undefined, empty text, and empty JSON responses
- return a friendly user-facing error and support common toast callback shapes
- preserve valid falsy payloads like 0 and false
- add regression tests for the empty-response and toast paths

## Test plan
- npm test