### PR TITLE
Handle empty API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,62 @@
+class ApiResponseError extends Error {
+  constructor(message, options = {}) {
+    super(message)
+    this.name = "ApiResponseError"
+    this.status = options.status
+    this.userMessage =
+      options.userMessage ||
+      "We could not load this data. Please try again in a moment."
+  }
+}
+
+function isEmptyResponseBody(body) {
+  return (
+    body === null ||
+    body === undefined ||
+    (typeof body === "string" && body.trim() === "")
+  )
+}
+
+async function parseApiResponse(response) {
+  if (!response) {
+    throw new ApiResponseError("API response was empty")
+  }
+
+  const status = response.status
+  const body =
+    typeof response.text === "function" ? await response.text() : response.body
+
+  if (isEmptyResponseBody(body)) {
+    throw new ApiResponseError("API returned an empty response body", { status })
+  }
+
+  if (typeof body !== "string") {
+    return body
+  }
+
+  try {
+    return JSON.parse(body)
+  } catch (error) {
+    throw new ApiResponseError("API returned invalid JSON", { status })
+  }
+}
+
+function toFriendlyError(error) {
+  if (error instanceof ApiResponseError) {
+    return {
+      message: error.userMessage,
+      status: error.status,
+    }
+  }
+
+  return {
+    message: "Something went wrong. Please try again.",
+  }
+}
+
+module.exports = {
+  ApiResponseError,
+  isEmptyResponseBody,
+  parseApiResponse,
+  toFriendlyError,
+}

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,90 @@
+const {
+  ApiResponseError,
+  isEmptyResponseBody,
+  parseApiResponse,
+  toFriendlyError,
+} = require("../src/api-response")
+
+let passed = 0
+let failed = 0
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a === e) {
+    console.log(`  OK ${name}`)
+    passed++
+  } else {
+    console.log(`  FAIL ${name}`)
+    console.log(`     Expected: ${e}`)
+    console.log(`     Actual:   ${a}`)
+    failed++
+  }
+}
+
+async function assertRejects(name, fn, check) {
+  try {
+    await fn()
+    console.log(`  FAIL ${name}`)
+    console.log("     Expected function to throw")
+    failed++
+  } catch (error) {
+    const result = check(error)
+    if (result) {
+      console.log(`  OK ${name}`)
+      passed++
+    } else {
+      console.log(`  FAIL ${name}`)
+      console.log(`     Unexpected error: ${error && error.message}`)
+      failed++
+    }
+  }
+}
+
+async function run() {
+  console.log("\nAPI Response Tests\n")
+
+  assert("detects null as empty", isEmptyResponseBody(null), true)
+  assert("detects undefined as empty", isEmptyResponseBody(undefined), true)
+  assert("detects blank string as empty", isEmptyResponseBody("   "), true)
+  assert("keeps JSON string as non-empty", isEmptyResponseBody('{"ok":true}'), false)
+
+  assert(
+    "parses JSON response text",
+    await parseApiResponse({ status: 200, text: async () => '{"items":[]}' }),
+    { items: [] },
+  )
+
+  assertRejects(
+    "throws friendly error for null response",
+    () => parseApiResponse(null),
+    (error) => error instanceof ApiResponseError,
+  )
+
+  await assertRejects(
+    "throws friendly error for empty response body",
+    () => parseApiResponse({ status: 204, text: async () => "" }),
+    (error) =>
+      error instanceof ApiResponseError &&
+      toFriendlyError(error).message ===
+        "We could not load this data. Please try again in a moment." &&
+      toFriendlyError(error).status === 204,
+  )
+
+  await assertRejects(
+    "throws friendly error for invalid JSON",
+    () => parseApiResponse({ status: 200, text: async () => "not json" }),
+    (error) => error instanceof ApiResponseError,
+  )
+
+  assert(
+    "maps unexpected errors to generic friendly message",
+    toFriendlyError(new Error("network failed")),
+    { message: "Something went wrong. Please try again." },
+  )
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed\n`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+run()


### PR DESCRIPTION
Fixes #35.\n\n## Summary\n- Add an API response helper that rejects null, undefined, blank, and invalid JSON responses with a friendly error type.\n- Add a user-facing error mapper for graceful error states.\n- Add tests covering empty responses, invalid JSON, successful parsing, and generic fallback errors.\n\n## Tests\n- npm test\n\nPayment wallet: pending.