### PR TITLE
feat: add bounty loading states

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/bounty-loading.test.js"
   },
   "license": "MIT"
 }

--- a/src/bounty-loading.js
+++ b/src/bounty-loading.js
@@ -1,0 +1,66 @@
+function createSpinnerMarkup(message = 'Loading bounties…') {
+  return `<div class="bounty-loading" role="status" aria-live="polite">
+  <span class="bounty-spinner" aria-hidden="true"></span>
+  <span>${escapeHtml(message)}</span>
+</div>`;
+}
+
+function createErrorMarkup(message = 'Unable to load bounties. Please try again.') {
+  return `<div class="bounty-error" role="alert">${escapeHtml(message)}</div>`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+async function loadBountiesWithState({
+  container,
+  fetchBounties,
+  renderBounties,
+  renderEmpty = () => '<p class="bounty-empty">No bounties found.</p>',
+  loadingMessage,
+  errorMessage,
+}) {
+  if (!container || typeof container !== 'object') {
+    throw new Error('container is required');
+  }
+  if (typeof fetchBounties !== 'function') {
+    throw new Error('fetchBounties must be a function');
+  }
+  if (typeof renderBounties !== 'function') {
+    throw new Error('renderBounties must be a function');
+  }
+
+  container.innerHTML = createSpinnerMarkup(loadingMessage);
+  container.dataset.state = 'loading';
+
+  try {
+    const bounties = await fetchBounties();
+    if (!Array.isArray(bounties) || bounties.length === 0) {
+      container.innerHTML = renderEmpty();
+      container.dataset.state = 'empty';
+      return bounties || [];
+    }
+
+    container.innerHTML = renderBounties(bounties);
+    container.dataset.state = 'loaded';
+    return bounties;
+  } catch (error) {
+    const message = errorMessage || (error && error.message) || 'Unable to load bounties. Please try again.';
+    container.innerHTML = createErrorMarkup(message);
+    container.dataset.state = 'error';
+    return [];
+  }
+}
+
+module.exports = {
+  createSpinnerMarkup,
+  createErrorMarkup,
+  loadBountiesWithState,
+  escapeHtml,
+};

--- a/test/bounty-loading.test.js
+++ b/test/bounty-loading.test.js
@@ -1,0 +1,74 @@
+const {
+  createSpinnerMarkup,
+  createErrorMarkup,
+  loadBountiesWithState,
+  escapeHtml,
+} = require('../src/bounty-loading');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${name}`);
+    if (detail) console.log(`     ${detail}`);
+    failed++;
+  }
+}
+
+function createContainer() {
+  return { innerHTML: '', dataset: {} };
+}
+
+async function run() {
+  console.log('\n📋 Bounty Loading State Tests\n');
+
+  const spinner = createSpinnerMarkup('Loading test');
+  assert('spinner has accessible status role', spinner.includes('role="status"'));
+  assert('spinner announces loading text', spinner.includes('Loading test'));
+
+  const escaped = escapeHtml('<script>alert("x")</script>');
+  assert('escapeHtml escapes dangerous markup', !escaped.includes('<script>') && escaped.includes('&lt;script&gt;'));
+
+  const error = createErrorMarkup('Bad <thing>');
+  assert('error has alert role', error.includes('role="alert"'));
+  assert('error message is escaped', error.includes('Bad &lt;thing&gt;'));
+
+  const loadedContainer = createContainer();
+  const loaded = await loadBountiesWithState({
+    container: loadedContainer,
+    fetchBounties: async () => [{ id: 1, title: 'Fix loading' }],
+    renderBounties: (items) => `<ul>${items.map((item) => `<li>${item.title}</li>`).join('')}</ul>`,
+  });
+  assert('loaded bounties are returned', loaded.length === 1);
+  assert('spinner disappears after successful load', !loadedContainer.innerHTML.includes('bounty-spinner'));
+  assert('loaded state is recorded', loadedContainer.dataset.state === 'loaded');
+  assert('rendered bounty appears', loadedContainer.innerHTML.includes('Fix loading'));
+
+  const emptyContainer = createContainer();
+  await loadBountiesWithState({
+    container: emptyContainer,
+    fetchBounties: async () => [],
+    renderBounties: () => '<ul></ul>',
+  });
+  assert('empty state is recorded', emptyContainer.dataset.state === 'empty');
+  assert('empty state renders helpful message', emptyContainer.innerHTML.includes('No bounties found'));
+
+  const errorContainer = createContainer();
+  const failedResult = await loadBountiesWithState({
+    container: errorContainer,
+    fetchBounties: async () => { throw new Error('API offline'); },
+    renderBounties: () => '<ul></ul>',
+  });
+  assert('failed fetch returns empty array', Array.isArray(failedResult) && failedResult.length === 0);
+  assert('error state is recorded', errorContainer.dataset.state === 'error');
+  assert('error state renders gracefully', errorContainer.innerHTML.includes('API offline'));
+
+  console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
## Summary
- Adds `src/bounty-loading.js` for bounty list loading, loaded, empty, and error states.
- Shows an accessible spinner (`role="status"`, `aria-live="polite"`) while the API call is pending.
- Removes the spinner once data loads and renders bounty results.
- Handles empty and failed API responses gracefully with explicit states and safe escaped error markup.
- Adds tests covering spinner rendering, successful load cleanup, empty state, error state, and HTML escaping.

## Validation
- `npm test`
- Result: 20 passed, 0 failed

Fixes #18

## BountyPay payout setup
Bounty: $50 USD1
Wallet: 0x4a76c7E64C08cF29B59eFC640b4ada97A270d428
Chain: BSC / BNB Smart Chain
Issues: #18
