### PR TITLE
Handle empty API responses gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,92 @@
+class FriendlyAPIError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = 'FriendlyAPIError';
+    this.cause = cause;
+  }
+}
+
+const DEFAULT_EMPTY_RESPONSE_MESSAGE =
+  'We could not load that data. Please try again in a moment.';
+
+function createErrorToast(message = DEFAULT_EMPTY_RESPONSE_MESSAGE) {
+  return {
+    type: 'error',
+    message,
+    ariaLive: 'polite',
+  };
+}
+
+function isEmptyResponseBody(body) {
+  return body === null || body === undefined || (typeof body === 'string' && body.trim() === '');
+}
+
+async function readResponseBody(response) {
+  if (response && typeof response.text === 'function') {
+    return response.text();
+  }
+
+  if (response && Object.prototype.hasOwnProperty.call(response, 'body')) {
+    return response.body;
+  }
+
+  return response;
+}
+
+async function parseAPIResponse(response, options = {}) {
+  const emptyMessage = options.emptyMessage || DEFAULT_EMPTY_RESPONSE_MESSAGE;
+
+  try {
+    const body = await readResponseBody(response);
+
+    if (isEmptyResponseBody(body)) {
+      throw new FriendlyAPIError(emptyMessage);
+    }
+
+    if (typeof body === 'string') {
+      return JSON.parse(body);
+    }
+
+    return body;
+  } catch (error) {
+    if (error instanceof FriendlyAPIError) {
+      throw error;
+    }
+
+    throw new FriendlyAPIError(
+      'We could not understand the response from the server. Please try again.',
+      error,
+    );
+  }
+}
+
+async function handleAPIResponse(response, options = {}) {
+  try {
+    return {
+      ok: true,
+      data: await parseAPIResponse(response, options),
+      toast: null,
+    };
+  } catch (error) {
+    const message =
+      error instanceof FriendlyAPIError
+        ? error.message
+        : DEFAULT_EMPTY_RESPONSE_MESSAGE;
+
+    return {
+      ok: false,
+      data: null,
+      error,
+      toast: createErrorToast(message),
+    };
+  }
+}
+
+module.exports = {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  FriendlyAPIError,
+  createErrorToast,
+  handleAPIResponse,
+  isEmptyResponseBody,
+  parseAPIResponse,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  FriendlyAPIError,
+  createErrorToast,
+  handleAPIResponse,
+  isEmptyResponseBody,
+  parseAPIResponse,
+} = require('../src/api-response');
+
+async function run() {
+  console.log('\nAPI Response Tests\n');
+
+  assert.equal(isEmptyResponseBody(null), true);
+  assert.equal(isEmptyResponseBody(undefined), true);
+  assert.equal(isEmptyResponseBody('   '), true);
+  assert.equal(isEmptyResponseBody('{"ok":true}'), false);
+
+  assert.deepEqual(await parseAPIResponse({ text: async () => '{"ok":true}' }), {
+    ok: true,
+  });
+
+  await assert.rejects(
+    () => parseAPIResponse({ text: async () => '' }),
+    (error) =>
+      error instanceof FriendlyAPIError &&
+      error.message === DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  );
+
+  const emptyResult = await handleAPIResponse({ text: async () => '' });
+  assert.equal(emptyResult.ok, false);
+  assert.equal(emptyResult.data, null);
+  assert.deepEqual(emptyResult.toast, createErrorToast(DEFAULT_EMPTY_RESPONSE_MESSAGE));
+
+  const customResult = await handleAPIResponse(
+    { body: null },
+    { emptyMessage: 'No bounty data was returned. Please refresh.' },
+  );
+  assert.equal(customResult.ok, false);
+  assert.deepEqual(
+    customResult.toast,
+    createErrorToast('No bounty data was returned. Please refresh.'),
+  );
+
+  const malformedResult = await handleAPIResponse({ text: async () => '{' });
+  assert.equal(malformedResult.ok, false);
+  assert.equal(
+    malformedResult.toast.message,
+    'We could not understand the response from the server. Please try again.',
+  );
+
+  const objectResult = await handleAPIResponse({ body: { items: [] } });
+  assert.deepEqual(objectResult, { ok: true, data: { items: [] }, toast: null });
+
+  console.log('  OK empty responses return friendly error toasts');
+  console.log('  OK valid JSON and object payloads are preserved');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes #35

/claim #35

## Summary
- Add a small API response helper that treats null, undefined, and empty response bodies as friendly user-facing failures instead of crashes.
- Return a toast payload for empty or malformed responses while preserving valid JSON/object payloads.
- Add regression coverage and include it in `npm test`.

## Verification
- `npm test`