### PR TITLE
test: add parser e2e fixture coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && npm run test:e2e",
+    "test:e2e": "node test/parser.e2e.test.js"
   },
   "license": "MIT"
 }

--- a/test/fixtures/orders.csv
+++ b/test/fixtures/orders.csv
@@ -1,0 +1,3 @@
+id, customer, total
+1001, Ada Lovelace, 42.50
+1002, Grace Hopper, 19.99

--- a/test/parser.e2e.test.js
+++ b/test/parser.e2e.test.js
@@ -1,0 +1,20 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { parseCSV } = require('../src/parser');
+
+const fixturePath = path.join(__dirname, 'fixtures', 'orders.csv');
+
+console.log('\nE2E CSV Parser Tests\n');
+
+const csv = fs.readFileSync(fixturePath, 'utf8');
+const parsed = parseCSV(csv);
+
+assert.deepEqual(parsed, [
+  ['id', 'customer', 'total'],
+  ['1001', 'Ada Lovelace', '42.50'],
+  ['1002', 'Grace Hopper', '19.99'],
+]);
+
+console.log('  OK parses the sample orders fixture from disk');
+console.log('\nE2E Results: 1 passed, 0 failed\n');


### PR DESCRIPTION
## Summary
- Adds an automated parser E2E test that reads a real CSV fixture from disk.
- Wires the E2E check into `npm test` through a dedicated `test:e2e` script.

## Verification
- `npm test`

Fixes #21
Fixes #30