### PR TITLE
feat: add theme toggle and loading state helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/theme-toggle.test.js && node test/loading-state.test.js"
   },
   "license": "MIT"
 }

--- a/src/loading-state.js
+++ b/src/loading-state.js
@@ -1,0 +1,40 @@
+function createSpinnerMarkup(label = 'Loading bounties') {
+  return `<div class="loading-spinner" role="status" aria-live="polite"><span>${label}</span></div>`;
+}
+
+async function loadBountyList(options) {
+  const {
+    fetchBounties,
+    renderLoading,
+    renderItems,
+    renderEmpty,
+    renderError,
+  } = options;
+
+  if (typeof fetchBounties !== 'function') {
+    throw new Error('fetchBounties must be a function');
+  }
+
+  renderLoading?.(createSpinnerMarkup());
+
+  try {
+    const bounties = await fetchBounties();
+    if (!Array.isArray(bounties)) {
+      throw new Error('Bounty response must be an array');
+    }
+    if (bounties.length === 0) {
+      renderEmpty?.();
+      return { status: 'empty', bounties };
+    }
+    renderItems?.(bounties);
+    return { status: 'loaded', bounties };
+  } catch (error) {
+    renderError?.(error);
+    return { status: 'error', error };
+  }
+}
+
+module.exports = {
+  createSpinnerMarkup,
+  loadBountyList,
+};

--- a/src/theme-toggle.js
+++ b/src/theme-toggle.js
@@ -1,0 +1,67 @@
+const STORAGE_KEY = 'preferred-theme';
+const THEMES = new Set(['light', 'dark']);
+
+function normalizeTheme(theme) {
+  return THEMES.has(theme) ? theme : 'light';
+}
+
+function getStoredTheme(storage) {
+  if (!storage || typeof storage.getItem !== 'function') {
+    return null;
+  }
+  return THEMES.has(storage.getItem(STORAGE_KEY)) ? storage.getItem(STORAGE_KEY) : null;
+}
+
+function applyTheme(root, storage, theme, options = {}) {
+  const nextTheme = normalizeTheme(theme);
+
+  if (root) {
+    root.dataset = root.dataset || {};
+    root.dataset.theme = nextTheme;
+    root.classList?.toggle?.('theme-transition', options.animate !== false);
+  }
+
+  if (storage && typeof storage.setItem === 'function') {
+    storage.setItem(STORAGE_KEY, nextTheme);
+  }
+
+  return nextTheme;
+}
+
+function toggleTheme(root, storage, currentTheme, options) {
+  const nextTheme = normalizeTheme(currentTheme) === 'dark' ? 'light' : 'dark';
+  return applyTheme(root, storage, nextTheme, options);
+}
+
+function createThemeToggleButton(documentRef, root, storage, options = {}) {
+  if (!documentRef || typeof documentRef.createElement !== 'function') {
+    throw new Error('documentRef must provide createElement');
+  }
+
+  let currentTheme = getStoredTheme(storage) || normalizeTheme(options.initialTheme);
+  applyTheme(root, storage, currentTheme, { animate: false });
+
+  const button = documentRef.createElement('button');
+  button.type = 'button';
+  button.className = options.className || 'theme-toggle';
+  button.textContent = options.label || 'Toggle theme';
+  button.setAttribute('aria-label', options.ariaLabel || 'Toggle light and dark theme');
+  button.setAttribute('aria-pressed', String(currentTheme === 'dark'));
+
+  button.addEventListener('click', () => {
+    currentTheme = toggleTheme(root, storage, currentTheme, { animate: true });
+    button.setAttribute('aria-pressed', String(currentTheme === 'dark'));
+    options.onChange?.(currentTheme);
+  });
+
+  return button;
+}
+
+module.exports = {
+  STORAGE_KEY,
+  applyTheme,
+  createThemeToggleButton,
+  getStoredTheme,
+  normalizeTheme,
+  toggleTheme,
+};

--- a/test/loading-state.test.js
+++ b/test/loading-state.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert/strict');
+const { createSpinnerMarkup, loadBountyList } = require('../src/loading-state');
+
+async function run() {
+  console.log('\nLoading State Tests\n');
+
+  assert.match(createSpinnerMarkup(), /role="status"/);
+  assert.match(createSpinnerMarkup(), /Loading bounties/);
+  console.log('  OK creates accessible spinner markup');
+
+  const successEvents = [];
+  const loaded = await loadBountyList({
+    fetchBounties: async () => [{ id: 1, title: 'Fix parser' }],
+    renderLoading: (markup) => successEvents.push(['loading', markup]),
+    renderItems: (items) => successEvents.push(['items', items.length]),
+  });
+  assert.equal(loaded.status, 'loaded');
+  assert.deepEqual(successEvents.map(([name]) => name), ['loading', 'items']);
+  console.log('  OK renders loading then loaded state');
+
+  const emptyEvents = [];
+  const empty = await loadBountyList({
+    fetchBounties: async () => [],
+    renderLoading: () => emptyEvents.push('loading'),
+    renderEmpty: () => emptyEvents.push('empty'),
+  });
+  assert.equal(empty.status, 'empty');
+  assert.deepEqual(emptyEvents, ['loading', 'empty']);
+  console.log('  OK renders empty state');
+
+  const errorEvents = [];
+  const failed = await loadBountyList({
+    fetchBounties: async () => {
+      throw new Error('Network failed');
+    },
+    renderLoading: () => errorEvents.push('loading'),
+    renderError: (error) => errorEvents.push(error.message),
+  });
+  assert.equal(failed.status, 'error');
+  assert.deepEqual(errorEvents, ['loading', 'Network failed']);
+  console.log('  OK renders error state gracefully');
+
+  console.log('\nLoading State Results: 4 passed, 0 failed\n');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/test/theme-toggle.test.js
+++ b/test/theme-toggle.test.js
@@ -1,0 +1,87 @@
+const assert = require('node:assert/strict');
+const {
+  STORAGE_KEY,
+  applyTheme,
+  createThemeToggleButton,
+  getStoredTheme,
+  normalizeTheme,
+  toggleTheme,
+} = require('../src/theme-toggle');
+
+function createStorage(initial = {}) {
+  const values = { ...initial };
+  return {
+    getItem: (key) => values[key] ?? null,
+    setItem: (key, value) => {
+      values[key] = value;
+    },
+  };
+}
+
+function createRoot() {
+  const classes = new Set();
+  return {
+    dataset: {},
+    classList: {
+      toggle: (name, enabled) => {
+        if (enabled) classes.add(name);
+        else classes.delete(name);
+      },
+      has: (name) => classes.has(name),
+    },
+  };
+}
+
+function createDocument() {
+  return {
+    createElement: () => {
+      const listeners = {};
+      return {
+        attributes: {},
+        addEventListener: (event, callback) => {
+          listeners[event] = callback;
+        },
+        click: () => listeners.click(),
+        setAttribute: function setAttribute(name, value) {
+          this.attributes[name] = value;
+        },
+      };
+    },
+  };
+}
+
+console.log('\nTheme Toggle Tests\n');
+
+assert.equal(normalizeTheme('dark'), 'dark');
+assert.equal(normalizeTheme('bad-value'), 'light');
+console.log('  OK normalizes unsupported themes');
+
+const storage = createStorage();
+const root = createRoot();
+assert.equal(applyTheme(root, storage, 'dark'), 'dark');
+assert.equal(root.dataset.theme, 'dark');
+assert.equal(storage.getItem(STORAGE_KEY), 'dark');
+console.log('  OK applies and persists dark theme');
+
+assert.equal(toggleTheme(root, storage, 'dark'), 'light');
+assert.equal(root.dataset.theme, 'light');
+assert.equal(getStoredTheme(storage), 'light');
+console.log('  OK toggles back to light theme');
+
+const buttonRoot = createRoot();
+const buttonStorage = createStorage({ [STORAGE_KEY]: 'dark' });
+let changedTheme = null;
+const button = createThemeToggleButton(createDocument(), buttonRoot, buttonStorage, {
+  onChange: (theme) => {
+    changedTheme = theme;
+  },
+});
+assert.equal(button.attributes['aria-pressed'], 'true');
+button.click();
+assert.equal(buttonRoot.dataset.theme, 'light');
+assert.equal(buttonStorage.getItem(STORAGE_KEY), 'light');
+assert.equal(button.attributes['aria-pressed'], 'false');
+assert.equal(changedTheme, 'light');
+console.log('  OK creates a persisted accessible toggle button');
+
+console.log('\nTheme Toggle Results: 4 passed, 0 failed\n');


### PR DESCRIPTION
## Summary
- Adds a reusable persisted light/dark theme toggle helper with localStorage support, accessible button state, and smooth transition hook.
- Adds a bounty list loading-state helper that renders spinner, loaded, empty, and error states cleanly.
- Adds focused regression tests for both helpers and wires them into `npm test`.

## Verification
- `npm test`

Fixes #11
Fixes #18
Fixes #19