### PR TITLE
Handle empty API responses

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -16,4 +16,16 @@ function parseCSV(text) {
   return rows.map(row => row.split(COMMA_PATTERN).map(cell => cell.trim()));
 }
 
-module.exports = { parseCSV };
+function parseAPIResponse(responseBody, notifyError) {
+  if (typeof responseBody !== 'string' || responseBody.trim() === '') {
+    const message = 'No CSV data was returned. Please try again later.';
+    if (typeof notifyError === 'function') {
+      notifyError(message);
+    }
+    return [];
+  }
+
+  return parseCSV(responseBody);
+}
+
+module.exports = { parseCSV, parseAPIResponse };

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,4 +1,4 @@
-const { parseCSV } = require('../src/parser');
+const { parseAPIResponse, parseCSV } = require('../src/parser');
 
 let passed = 0;
 let failed = 0;
@@ -58,6 +58,26 @@ assert(
 let threwError = false;
 try { parseCSV(''); } catch (e) { threwError = true; }
 assert('throws on empty input', threwError, true);
+
+// Test 7: Empty API responses show a friendly error instead of throwing
+let errorToast = '';
+assert(
+  'handles empty API response body with a friendly error',
+  parseAPIResponse(undefined, message => { errorToast = message; }),
+  []
+);
+assert(
+  'reports friendly empty response error',
+  errorToast,
+  'No CSV data was returned. Please try again later.'
+);
+
+// Test 8: Non-empty API responses still parse as CSV
+assert(
+  'parses non-empty API response body',
+  parseAPIResponse('name,age\nAda,36'),
+  [['name', 'age'], ['Ada', '36']]
+);
 
 console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Fixes #35.

Changes:
- Add parseAPIResponse to handle null, undefined, and empty response bodies without throwing.
- Surface a friendly error message through the provided notification callback.
- Add tests for the empty-response path and normal non-empty API parsing.

Tested:
- npm test