### PR TITLE
Handle empty API responses without crashes

### DIFF
--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,64 @@
+class ApiResponseError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'ApiResponseError';
+    this.status = options.status;
+    this.toast = {
+      type: 'error',
+      message,
+    };
+  }
+}
+
+async function normalizeApiResponse(response) {
+  if (response === null || response === undefined) {
+    throw new ApiResponseError('The server returned an empty response. Please try again.');
+  }
+
+  const status = typeof response.status === 'number' ? response.status : undefined;
+  const ok = typeof response.ok === 'boolean' ? response.ok : true;
+  const hasJson = typeof response.json === 'function';
+  const hasText = typeof response.text === 'function';
+
+  if (!hasJson && !hasText) {
+    if (!ok) {
+      throw new ApiResponseError('The request failed. Please try again.', { status });
+    }
+    return response;
+  }
+
+  let body;
+  if (hasJson) {
+    try {
+      body = await response.json();
+    } catch (error) {
+      if (!hasText) {
+        throw new ApiResponseError('The server returned invalid data. Please try again.', { status });
+      }
+    }
+  }
+
+  if (body === undefined && hasText) {
+    const text = await response.text();
+    if (text.trim() === '') {
+      throw new ApiResponseError('The server returned an empty response. Please try again.', { status });
+    }
+    try {
+      body = JSON.parse(text);
+    } catch (error) {
+      body = text;
+    }
+  }
+
+  if (body === null || body === undefined) {
+    throw new ApiResponseError('The server returned an empty response. Please try again.', { status });
+  }
+
+  if (!ok) {
+    throw new ApiResponseError('The request failed. Please try again.', { status });
+  }
+
+  return body;
+}
+
+module.exports = { ApiResponseError, normalizeApiResponse };

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,74 @@
+const { ApiResponseError, normalizeApiResponse } = require('../src/api-response');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  OK ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+async function assertRejectsWithToast(name, promise, expectedMessage) {
+  try {
+    await promise;
+    console.log(`  FAIL ${name}`);
+    console.log('     Expected rejection');
+    failed++;
+  } catch (error) {
+    assert(name, {
+      isApiResponseError: error instanceof ApiResponseError,
+      message: error.message,
+      toast: error.toast,
+    }, {
+      isApiResponseError: true,
+      message: expectedMessage,
+      toast: { type: 'error', message: expectedMessage },
+    });
+  }
+}
+
+(async () => {
+  console.log('\nAPI Response Tests\n');
+
+  await assertRejectsWithToast(
+    'rejects null responses with toast payload',
+    normalizeApiResponse(null),
+    'The server returned an empty response. Please try again.'
+  );
+
+  await assertRejectsWithToast(
+    'rejects empty text bodies with toast payload',
+    normalizeApiResponse({ ok: true, text: async () => '   ' }),
+    'The server returned an empty response. Please try again.'
+  );
+
+  assert(
+    'returns JSON response bodies',
+    await normalizeApiResponse({ ok: true, json: async () => ({ id: 1 }) }),
+    { id: 1 }
+  );
+
+  assert(
+    'preserves valid falsy JSON values',
+    await normalizeApiResponse({ ok: true, json: async () => false }),
+    false
+  );
+
+  await assertRejectsWithToast(
+    'rejects failed responses with toast payload',
+    normalizeApiResponse({ ok: false, status: 500, json: async () => ({ error: 'boom' }) }),
+    'The request failed. Please try again.'
+  );
+
+  console.log(`\nAPI Response Results: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})();


### PR DESCRIPTION
Closes #35
/claim #35 
Adds src/api-response.js to normalize empty API responses into ApiResponseError with a toast payload.
Adds test/api-response.test.js covering null, empty text, valid JSON, valid false, and failed responses.

Verification:
npm test
node test/api-response.test.js
