### PR TITLE
Handle empty API responses without crashing

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -16,4 +16,34 @@ function parseCSV(text) {
   return rows.map(row => row.split(COMMA_PATTERN).map(cell => cell.trim()));
 }
 
-module.exports = { parseCSV };
+function createErrorToast(message) {
+  return {
+    type: 'error',
+    title: 'Unable to load bounties',
+    message,
+  };
+}
+
+function parseApiResponseBody(body) {
+  if (body === null || body === undefined || body === '') {
+    return {
+      data: null,
+      error: createErrorToast('The API returned an empty response. Please try again.'),
+    };
+  }
+
+  if (typeof body === 'object') {
+    return { data: body, error: null };
+  }
+
+  try {
+    return { data: JSON.parse(body), error: null };
+  } catch (error) {
+    return {
+      data: null,
+      error: createErrorToast('The API returned an invalid response. Please try again.'),
+    };
+  }
+}
+
+module.exports = { parseCSV, parseApiResponseBody, createErrorToast };

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,4 +1,4 @@
-const { parseCSV } = require('../src/parser');
+const { parseCSV, parseApiResponseBody } = require('../src/parser');
 
 let passed = 0;
 let failed = 0;
@@ -7,17 +7,17 @@ function assert(name, actual, expected) {
   const a = JSON.stringify(actual);
   const e = JSON.stringify(expected);
   if (a === e) {
-    console.log(`  ✅ ${name}`);
+    console.log(`  OK ${name}`);
     passed++;
   } else {
-    console.log(`  ❌ ${name}`);
+    console.log(`  FAIL ${name}`);
     console.log(`     Expected: ${e}`);
     console.log(`     Actual:   ${a}`);
     failed++;
   }
 }
 
-console.log('\n📋 CSV Parser Tests\n');
+console.log('\nCSV Parser Tests\n');
 
 // Test 1: Basic CSV with ASCII commas
 assert(
@@ -59,5 +59,40 @@ let threwError = false;
 try { parseCSV(''); } catch (e) { threwError = true; }
 assert('throws on empty input', threwError, true);
 
-console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
+// Test 7: Empty API responses no longer crash
+assert(
+  'returns a friendly error toast for empty API responses',
+  parseApiResponseBody(''),
+  {
+    data: null,
+    error: {
+      type: 'error',
+      title: 'Unable to load bounties',
+      message: 'The API returned an empty response. Please try again.',
+    },
+  }
+);
+
+// Test 8: Null API responses no longer crash
+assert(
+  'returns a friendly error toast for null API responses',
+  parseApiResponseBody(null),
+  {
+    data: null,
+    error: {
+      type: 'error',
+      title: 'Unable to load bounties',
+      message: 'The API returned an empty response. Please try again.',
+    },
+  }
+);
+
+// Test 9: Valid JSON still parses
+assert(
+  'parses valid JSON API response bodies',
+  parseApiResponseBody('{"items":[{"id":1}]}'),
+  { data: { items: [{ id: 1 }] }, error: null }
+);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Fixes #35

## Summary
- Add a small API response parser that treats `null`, `undefined`, and empty response bodies as friendly error-toast payloads instead of throwing a TypeError.
- Preserve valid object and JSON string responses.
- Add regression coverage for empty and null API response bodies.

## Validation
- `npm test` ? 9 passed, 0 failed
- `node --check src/parser.js`
- `node --check test/parser.test.js`
