### PR TITLE
fix: handle empty api responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/api-response.test.js"
   },
   "license": "MIT"
 }

--- a/src/api-response.js
+++ b/src/api-response.js
@@ -1,0 +1,63 @@
+const DEFAULT_EMPTY_RESPONSE_MESSAGE =
+  'We could not load data from the API. Please try again in a moment.';
+
+function createToast(message, type = 'error') {
+  return { type, message };
+}
+
+function isEmptyResponse(response) {
+  if (response === null || response === undefined) {
+    return true;
+  }
+
+  if (typeof response === 'string') {
+    return response.trim().length === 0;
+  }
+
+  if (Array.isArray(response)) {
+    return response.length === 0;
+  }
+
+  return typeof response === 'object' && Object.keys(response).length === 0;
+}
+
+function parseApiResponse(response, options = {}) {
+  const message = options.emptyMessage || DEFAULT_EMPTY_RESPONSE_MESSAGE;
+
+  if (isEmptyResponse(response)) {
+    return {
+      ok: false,
+      data: null,
+      toast: createToast(message),
+    };
+  }
+
+  if (typeof response === 'string') {
+    try {
+      return {
+        ok: true,
+        data: JSON.parse(response),
+        toast: null,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        data: null,
+        toast: createToast('The API returned malformed data. Please try again later.'),
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    data: response,
+    toast: null,
+  };
+}
+
+module.exports = {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  createToast,
+  isEmptyResponse,
+  parseApiResponse,
+};

--- a/test/api-response.test.js
+++ b/test/api-response.test.js
@@ -1,0 +1,81 @@
+const {
+  DEFAULT_EMPTY_RESPONSE_MESSAGE,
+  isEmptyResponse,
+  parseApiResponse,
+} = require('../src/api-response');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  PASS ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+console.log('\nAPI Response Tests\n');
+
+assert('treats null as an empty response', isEmptyResponse(null), true);
+assert('treats undefined as an empty response', isEmptyResponse(undefined), true);
+assert('treats an empty string as an empty response', isEmptyResponse('   '), true);
+assert('treats an empty object as an empty response', isEmptyResponse({}), true);
+
+assert(
+  'returns a friendly toast for null responses',
+  parseApiResponse(null),
+  {
+    ok: false,
+    data: null,
+    toast: {
+      type: 'error',
+      message: DEFAULT_EMPTY_RESPONSE_MESSAGE,
+    },
+  },
+);
+
+assert(
+  'returns a friendly toast for undefined responses',
+  parseApiResponse(undefined, { emptyMessage: 'No API data was returned.' }),
+  {
+    ok: false,
+    data: null,
+    toast: {
+      type: 'error',
+      message: 'No API data was returned.',
+    },
+  },
+);
+
+assert(
+  'parses valid JSON responses',
+  parseApiResponse('{"items":[1,2]}'),
+  {
+    ok: true,
+    data: { items: [1, 2] },
+    toast: null,
+  },
+);
+
+assert(
+  'returns a friendly toast for malformed JSON responses',
+  parseApiResponse('{'),
+  {
+    ok: false,
+    data: null,
+    toast: {
+      type: 'error',
+      message: 'The API returned malformed data. Please try again later.',
+    },
+  },
+);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- add an API response helper that treats null, undefined, blank strings, empty arrays, and empty objects as empty responses
- return a friendly error toast instead of throwing when the API returns no usable data
- handle malformed JSON with a safe toast and keep valid JSON/object responses passing through

## Testing
- npm test

Fixes #35