### PR TITLE
test: add parser e2e fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && npm run test:e2e",
+    "test:e2e": "node test/e2e-parser.test.js"
   },
   "license": "MIT"
 }

--- a/test/e2e-parser.test.js
+++ b/test/e2e-parser.test.js
@@ -1,0 +1,63 @@
+const { parseCSV } = require('../src/parser');
+
+const fixtures = [
+  {
+    name: 'ASCII comma export',
+    input: 'name,age,city\nAlice,31,Toronto\nBob,28,Vancouver',
+    expected: [
+      ['name', 'age', 'city'],
+      ['Alice', '31', 'Toronto'],
+      ['Bob', '28', 'Vancouver'],
+    ],
+  },
+  {
+    name: 'Chinese full-width comma export',
+    input: 'name，age，city\nTristan，22，Toronto',
+    expected: [
+      ['name', 'age', 'city'],
+      ['Tristan', '22', 'Toronto'],
+    ],
+  },
+  {
+    name: 'mixed comma export with whitespace',
+    input: 'name, age， city\nMing, 40， Markham',
+    expected: [
+      ['name', 'age', 'city'],
+      ['Ming', '40', 'Markham'],
+    ],
+  },
+];
+
+let passed = 0;
+let failed = 0;
+
+function assertFixture(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  OK ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+console.log('\nParser E2E fixture tests\n');
+
+for (const fixture of fixtures) {
+  assertFixture(fixture.name, parseCSV(fixture.input), fixture.expected);
+}
+
+let rejectedEmptyInput = false;
+try {
+  parseCSV('');
+} catch (error) {
+  rejectedEmptyInput = /non-empty string/.test(error.message);
+}
+assertFixture('rejects empty export input', rejectedEmptyInput, true);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- add automated parser E2E fixture coverage for ASCII comma exports
- cover Chinese full-width comma exports and mixed comma exports with whitespace
- wire the E2E test into npm test via npm run test:e2e

## Testing
- npm test

Fixes #21
Fixes #30