### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ The CSV parser does not handle Chinese full-width commas (U+FF0C `，`). See Iss
 
 ## Error Handling
 Added proper timeout handling for all API calls.
-// Webhook integration implemented
+Webhook integration implemented.


### PR DESCRIPTION
Fixed the formatting issue in the Error Handling section of the README.md file.