### PR TITLE
Add persisted navbar theme toggle helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/theme-toggle.test.js"
   },
   "license": "MIT"
 }

--- a/src/theme-toggle.js
+++ b/src/theme-toggle.js
@@ -1,0 +1,84 @@
+const THEME_STORAGE_KEY = 'ai-agent-pay-demo.theme';
+const THEMES = new Set(['light', 'dark']);
+
+function safeGet(storage, key) {
+  try {
+    return storage && typeof storage.getItem === 'function' ? storage.getItem(key) : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function safeSet(storage, key, value) {
+  try {
+    if (storage && typeof storage.setItem === 'function') {
+      storage.setItem(key, value);
+    }
+  } catch (_error) {
+    // Ignore storage failures so private browsing modes still allow toggling.
+  }
+}
+
+function normalizeTheme(theme, fallback = 'light') {
+  return THEMES.has(theme) ? theme : fallback;
+}
+
+function resolveInitialTheme({ storage, prefersDark = false } = {}) {
+  const stored = safeGet(storage, THEME_STORAGE_KEY);
+  return normalizeTheme(stored, prefersDark ? 'dark' : 'light');
+}
+
+function applyTheme(root, theme) {
+  const normalized = normalizeTheme(theme);
+  if (!root) {
+    return normalized;
+  }
+
+  root.dataset.theme = normalized;
+  root.classList.remove('theme-light', 'theme-dark');
+  root.classList.add(`theme-${normalized}`, 'theme-transition');
+  return normalized;
+}
+
+function createThemeToggle({ storage, root, prefersDark = false } = {}) {
+  let currentTheme = resolveInitialTheme({ storage, prefersDark });
+
+  function setTheme(nextTheme) {
+    currentTheme = applyTheme(root, nextTheme);
+    safeSet(storage, THEME_STORAGE_KEY, currentTheme);
+    return getButtonState();
+  }
+
+  function toggleTheme() {
+    return setTheme(currentTheme === 'dark' ? 'light' : 'dark');
+  }
+
+  function getButtonState() {
+    return {
+      type: 'button',
+      ariaLabel: `Switch to ${currentTheme === 'dark' ? 'light' : 'dark'} mode`,
+      text: currentTheme === 'dark' ? 'Light mode' : 'Dark mode',
+      pressed: currentTheme === 'dark',
+      theme: currentTheme,
+    };
+  }
+
+  return {
+    initialize() {
+      return setTheme(currentTheme);
+    },
+    getTheme() {
+      return currentTheme;
+    },
+    getButtonState,
+    setTheme,
+    toggleTheme,
+  };
+}
+
+module.exports = {
+  THEME_STORAGE_KEY,
+  applyTheme,
+  createThemeToggle,
+  resolveInitialTheme,
+};

--- a/test/theme-toggle.test.js
+++ b/test/theme-toggle.test.js
@@ -1,0 +1,99 @@
+const {
+  THEME_STORAGE_KEY,
+  applyTheme,
+  createThemeToggle,
+  resolveInitialTheme,
+} = require('../src/theme-toggle');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+function createStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+    snapshot() {
+      return { ...data };
+    },
+  };
+}
+
+function createRoot() {
+  const classes = new Set();
+  return {
+    dataset: {},
+    classList: {
+      add(...names) {
+        names.forEach((name) => classes.add(name));
+      },
+      remove(...names) {
+        names.forEach((name) => classes.delete(name));
+      },
+      snapshot() {
+        return Array.from(classes).sort();
+      },
+    },
+  };
+}
+
+console.log('\n🎨 Theme Toggle Tests\n');
+
+assert(
+  'uses stored theme before system preference',
+  resolveInitialTheme({
+    storage: createStorage({ [THEME_STORAGE_KEY]: 'light' }),
+    prefersDark: true,
+  }),
+  'light'
+);
+
+assert(
+  'falls back to system dark preference',
+  resolveInitialTheme({ storage: createStorage(), prefersDark: true }),
+  'dark'
+);
+
+const root = createRoot();
+assert('applies theme class', applyTheme(root, 'dark'), 'dark');
+assert('sets data-theme', root.dataset.theme, 'dark');
+assert('sets transition class', root.classList.snapshot(), ['theme-dark', 'theme-transition']);
+
+const storage = createStorage();
+const toggle = createThemeToggle({ storage, root: createRoot() });
+assert('initializes light button state', toggle.initialize(), {
+  type: 'button',
+  ariaLabel: 'Switch to dark mode',
+  text: 'Dark mode',
+  pressed: false,
+  theme: 'light',
+});
+assert('toggles to dark', toggle.toggleTheme(), {
+  type: 'button',
+  ariaLabel: 'Switch to light mode',
+  text: 'Light mode',
+  pressed: true,
+  theme: 'dark',
+});
+assert('persists dark theme', storage.snapshot()[THEME_STORAGE_KEY], 'dark');
+
+console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- add a reusable theme toggle controller for navbar integration
- persist light/dark preference in localStorage and apply `data-theme` plus transition classes
- add Node-based tests for stored preference, system fallback, root class updates, button state, and persistence

## Validation
- `npm test`
- `git diff --check`

Closes #19