### PR TITLE
Add bounty list loading state helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/bounty-list-state.test.js"
   },
   "license": "MIT"
 }

--- a/src/bounty-list-state.js
+++ b/src/bounty-list-state.js
@@ -1,0 +1,81 @@
+function createLoadingState(message = 'Loading bounties...') {
+  return {
+    status: 'loading',
+    showSpinner: true,
+    items: [],
+    message,
+    error: null,
+  };
+}
+
+function createSuccessState(items) {
+  return {
+    status: 'ready',
+    showSpinner: false,
+    items: Array.isArray(items) ? items : [],
+    message: '',
+    error: null,
+  };
+}
+
+function createErrorState(error) {
+  const message = error && error.message ? error.message : 'Unable to load bounties. Please try again.';
+  return {
+    status: 'error',
+    showSpinner: false,
+    items: [],
+    message,
+    error: message,
+  };
+}
+
+async function loadBounties(fetchBounties, onStateChange = () => {}) {
+  if (typeof fetchBounties !== 'function') {
+    throw new TypeError('fetchBounties must be a function');
+  }
+
+  onStateChange(createLoadingState());
+
+  try {
+    const items = await fetchBounties();
+    const state = createSuccessState(items);
+    onStateChange(state);
+    return state;
+  } catch (error) {
+    const state = createErrorState(error);
+    onStateChange(state);
+    return state;
+  }
+}
+
+function renderBountyListState(state) {
+  if (state.status === 'loading') {
+    return {
+      role: 'status',
+      text: state.message,
+      spinner: true,
+    };
+  }
+
+  if (state.status === 'error') {
+    return {
+      role: 'alert',
+      text: state.message,
+      spinner: false,
+    };
+  }
+
+  return {
+    role: 'list',
+    count: state.items.length,
+    spinner: false,
+  };
+}
+
+module.exports = {
+  createErrorState,
+  createLoadingState,
+  createSuccessState,
+  loadBounties,
+  renderBountyListState,
+};

--- a/test/bounty-list-state.test.js
+++ b/test/bounty-list-state.test.js
@@ -1,0 +1,89 @@
+const {
+  createErrorState,
+  createLoadingState,
+  createSuccessState,
+  loadBounties,
+  renderBountyListState,
+} = require('../src/bounty-list-state');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${name}`);
+    console.log(`     Expected: ${e}`);
+    console.log(`     Actual:   ${a}`);
+    failed++;
+  }
+}
+
+async function run() {
+  console.log('\n⏳ Bounty List State Tests\n');
+
+  assert('loading state shows spinner', createLoadingState(), {
+    status: 'loading',
+    showSpinner: true,
+    items: [],
+    message: 'Loading bounties...',
+    error: null,
+  });
+
+  assert('success state hides spinner', createSuccessState([{ id: 1 }]), {
+    status: 'ready',
+    showSpinner: false,
+    items: [{ id: 1 }],
+    message: '',
+    error: null,
+  });
+
+  assert('error state hides spinner and shows friendly message', createErrorState(new Error('Network down')), {
+    status: 'error',
+    showSpinner: false,
+    items: [],
+    message: 'Network down',
+    error: 'Network down',
+  });
+
+  const states = [];
+  const finalState = await loadBounties(
+    async () => [{ id: 'bounty-1', title: 'Fix parser' }],
+    (state) => states.push(state.status)
+  );
+
+  assert('loadBounties emits loading then ready', states, ['loading', 'ready']);
+  assert('loadBounties returns ready state', finalState.status, 'ready');
+
+  const errorStates = [];
+  const errorState = await loadBounties(
+    async () => {
+      throw new Error('API unavailable');
+    },
+    (state) => errorStates.push(state.status)
+  );
+
+  assert('loadBounties emits loading then error', errorStates, ['loading', 'error']);
+  assert('loadBounties returns error message', errorState.message, 'API unavailable');
+
+  assert('render loading state as status spinner', renderBountyListState(createLoadingState()), {
+    role: 'status',
+    text: 'Loading bounties...',
+    spinner: true,
+  });
+
+  assert('render error state as alert', renderBountyListState(errorState), {
+    role: 'alert',
+    text: 'API unavailable',
+    spinner: false,
+  });
+
+  console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a reusable bounty list state helper with loading, ready, and error states
- expose render metadata for status spinner and alert states
- add Node tests for spinner visibility, async success/error transitions, and render output

## Validation
- `npm test`
- `git diff --check`

Closes #18