### PR TITLE
Add settings dark mode toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CSV parser - BountyPay workflow demo",
   "main": "src/parser.js",
   "scripts": {
-    "test": "node test/parser.test.js"
+    "test": "node test/parser.test.js && node test/dark-mode.test.js"
   },
   "license": "MIT"
 }

--- a/src/dark-mode.js
+++ b/src/dark-mode.js
@@ -1,0 +1,83 @@
+const DARK_MODE_STORAGE_KEY = 'settings.darkMode'
+
+function normalizeStoredPreference(value) {
+  return value === 'dark'
+}
+
+function persistPreference(storage, isDarkMode) {
+  if (!storage || typeof storage.setItem !== 'function') {
+    return
+  }
+
+  storage.setItem(DARK_MODE_STORAGE_KEY, isDarkMode ? 'dark' : 'light')
+}
+
+function applyDarkMode(root, isDarkMode) {
+  if (!root) {
+    return isDarkMode
+  }
+
+  if (root.classList && typeof root.classList.toggle === 'function') {
+    root.classList.toggle('dark', isDarkMode)
+  }
+
+  if (typeof root.setAttribute === 'function') {
+    root.setAttribute('data-theme', isDarkMode ? 'dark' : 'light')
+  } else {
+    root.dataset = root.dataset || {}
+    root.dataset.theme = isDarkMode ? 'dark' : 'light'
+  }
+
+  return isDarkMode
+}
+
+function readDarkModePreference(storage) {
+  if (!storage || typeof storage.getItem !== 'function') {
+    return false
+  }
+
+  return normalizeStoredPreference(storage.getItem(DARK_MODE_STORAGE_KEY))
+}
+
+function createDarkModeController(options = {}) {
+  const root = options.root
+  const storage = options.storage
+  let isDarkMode = readDarkModePreference(storage)
+
+  applyDarkMode(root, isDarkMode)
+
+  return {
+    get isDarkMode() {
+      return isDarkMode
+    },
+    setDarkMode(nextValue) {
+      isDarkMode = Boolean(nextValue)
+      persistPreference(storage, isDarkMode)
+      applyDarkMode(root, isDarkMode)
+      return isDarkMode
+    },
+    toggleDarkMode() {
+      return this.setDarkMode(!isDarkMode)
+    },
+  }
+}
+
+function bindDarkModeToggle(button, options = {}) {
+  const controller = createDarkModeController(options)
+
+  if (button && typeof button.addEventListener === 'function') {
+    button.addEventListener('click', () => {
+      controller.toggleDarkMode()
+    })
+  }
+
+  return controller
+}
+
+module.exports = {
+  DARK_MODE_STORAGE_KEY,
+  applyDarkMode,
+  bindDarkModeToggle,
+  createDarkModeController,
+  readDarkModePreference,
+}

--- a/test/dark-mode.test.js
+++ b/test/dark-mode.test.js
@@ -1,0 +1,114 @@
+const {
+  DARK_MODE_STORAGE_KEY,
+  bindDarkModeToggle,
+  createDarkModeController,
+  readDarkModePreference,
+} = require('../src/dark-mode')
+
+let passed = 0
+let failed = 0
+
+function assert(name, actual, expected) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a === e) {
+    console.log(`  OK ${name}`)
+    passed++
+  } else {
+    console.log(`  FAIL ${name}`)
+    console.log(`     Expected: ${e}`)
+    console.log(`     Actual:   ${a}`)
+    failed++
+  }
+}
+
+function createStorage(initial = {}) {
+  const values = { ...initial }
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : null
+    },
+    setItem(key, value) {
+      values[key] = String(value)
+    },
+    values,
+  }
+}
+
+function createRoot() {
+  const classes = new Set()
+  return {
+    attributes: {},
+    classList: {
+      toggle(name, enabled) {
+        if (enabled) {
+          classes.add(name)
+        } else {
+          classes.delete(name)
+        }
+      },
+      contains(name) {
+        return classes.has(name)
+      },
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = value
+    },
+  }
+}
+
+function createButton() {
+  const listeners = {}
+  return {
+    addEventListener(eventName, handler) {
+      listeners[eventName] = handler
+    },
+    click() {
+      listeners.click()
+    },
+  }
+}
+
+console.log('\nDark Mode Settings Tests\n')
+
+assert(
+  'reads dark preference from localStorage',
+  readDarkModePreference(createStorage({ [DARK_MODE_STORAGE_KEY]: 'dark' })),
+  true
+)
+
+assert(
+  'defaults to light mode without a saved preference',
+  readDarkModePreference(createStorage()),
+  false
+)
+
+const storage = createStorage()
+const root = createRoot()
+const controller = createDarkModeController({ root, storage })
+
+assert('starts in light mode', controller.isDarkMode, false)
+assert('sets light data-theme on init', root.attributes['data-theme'], 'light')
+
+controller.toggleDarkMode()
+assert('toggles into dark mode', controller.isDarkMode, true)
+assert('persists dark mode to localStorage', storage.values[DARK_MODE_STORAGE_KEY], 'dark')
+assert('adds dark class to root', root.classList.contains('dark'), true)
+assert('sets dark data-theme', root.attributes['data-theme'], 'dark')
+
+controller.setDarkMode(false)
+assert('can return to light mode', controller.isDarkMode, false)
+assert('persists light mode to localStorage', storage.values[DARK_MODE_STORAGE_KEY], 'light')
+assert('removes dark class from root', root.classList.contains('dark'), false)
+
+const buttonStorage = createStorage()
+const buttonRoot = createRoot()
+const button = createButton()
+bindDarkModeToggle(button, { root: buttonRoot, storage: buttonStorage })
+button.click()
+
+assert('bound settings button toggles dark mode', buttonStorage.values[DARK_MODE_STORAGE_KEY], 'dark')
+assert('bound settings button updates root theme', buttonRoot.attributes['data-theme'], 'dark')
+
+console.log(`\nDark Mode Results: ${passed} passed, ${failed} failed\n`)
+process.exit(failed > 0 ? 1 : 0)


### PR DESCRIPTION
## Summary
- add a settings dark mode controller that initializes from localStorage
- persist light/dark preference back to localStorage when toggled
- update the root element with a dark class and data-theme for UI styling hooks
- add Node-based tests for initialization, persistence, root updates, and button binding

Closes #11

Bounty: $50 USD1
Wallet: 0xb90760f7d1f5c8dc99b7325a7da7bc407f133bb4

## Verification
- npm test
